### PR TITLE
Add Boost as a required package

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,11 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_package(Eigen3)
 include_directories(${EIGEN3_INCLUDE_DIR})
 
+find_package(Boost REQUIRED)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+endif()
+
 include(CheckCXXCompilerFlag)
 
 # Check for -march=native support in the compiler

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,10 @@ if (CMAKE_VERSION VERSION_LESS 2.8.11)
   include_directories("${gtest_SOURCE_DIR}/include")
 endif()
 
-
+find_package(Boost REQUIRED)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+endif()
 
 find_package(MPI REQUIRED)
 


### PR DESCRIPTION
This allows us to be sure we have everything we need before trying to
build the project.