### PR TITLE
Reduce locking

### DIFF
--- a/src/BayesRRmz.cpp
+++ b/src/BayesRRmz.cpp
@@ -376,6 +376,7 @@ void BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx)
         });
     }
     VectorXd v = VectorXd(K);
+    v.setZero();
     for (int k = 0; k < K; k++) {
         if (p <= acum) {
             //if zeroth component

--- a/src/BayesRRmz.cpp
+++ b/src/BayesRRmz.cpp
@@ -402,16 +402,16 @@ void BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx)
 
     // Update our local copy of epsilon to minimise the amount of time we need to hold the unique lock for.
     if (!skipUpdate) {
-        epsilon = y_tilde - beta * Cx;
+        y_tilde -= beta * Cx;
     }
-    // Now epsilon contains Y-mu - X*beta + X.col(marker) * beta(marker)_old - X.col(marker) * beta(marker)_new
+    // Now y_tilde contains Y-mu - X*beta + X.col(marker) * beta(marker)_old - X.col(marker) * beta(marker)_new
 
     // Lock to write updates (at end, or perhaps as updates are computed)
     {
         // Use a unique lock to ensure only one thread can write updates
         std::unique_lock lock(m_mutex);
         if (!skipUpdate) {
-            std::memcpy(m_epsilon.data(), epsilon.data(), static_cast<size_t>(epsilon.size()) * sizeof(double));
+            std::memcpy(m_epsilon.data(), y_tilde.data(), static_cast<size_t>(y_tilde.size()) * sizeof(double));
             m_betasqn += beta * beta - beta_old * beta_old;
         }
         m_v += v;

--- a/src/parallelgraph.cpp
+++ b/src/parallelgraph.cpp
@@ -62,6 +62,10 @@ void ParallelGraph::exec(unsigned int numKeptInds,
                          unsigned int numIncdSnps,
                          const std::vector<unsigned int> &markerIndices)
 {
+    // Do not allow Eigen to parallalize during ParallelGraph execution.
+    const auto eigenThreadCount = Eigen::nbThreads( );
+    Eigen::setNbThreads(0);
+
     // Reset the graph from the previous iteration. This resets the sequencer node current index etc.
     m_graph->reset();
 
@@ -73,4 +77,7 @@ void ParallelGraph::exec(unsigned int numKeptInds,
 
     // Wait for the graph to complete
     m_graph->wait_for_all();
+
+    // Turn Eigen threading back on.
+    Eigen::setNbThreads(eigenThreadCount);
 }


### PR DESCRIPTION
Implement the changes discussed via email.

Assumes that it is fine to update m_beta and m_components without locking.

I'm not sure that the Eigen multi-threading change adds much - it is only used in a limited set of algorithms: https://eigen.tuxfamily.org/dox/TopicMultiThreading.html

In my tests, the flowgraph duration is now only 0.01s slower than running the same code without mutex locking. I think we need to look at how we can speed up the code in the for loop that calls `m_flowgraph->exec`. The call to `exec` takes only half of each iteration duration. Iteration duration can vary significantly, but the call to `exec` is very consistent.