### PR TITLE
Fix compression size calculations

### DIFF
--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -16,7 +16,7 @@ unsigned long maxCompressedDataSize(const unsigned int numFloats)
         return 0;
 
     // Calculate the maximum buffer size needed to hold the compressed data
-    const unsigned int inputSize = numFloats * sizeof(float);
+    const unsigned int inputSize = numFloats * sizeof(double);
     strm.avail_in = inputSize;
     const auto maxOutputSize = deflateBound(&strm, inputSize);
     //std::cout << "maxSize = " << maxOutputSize << " bytes = " << maxOutputSize / 1024 << " KiB" << std::endl;
@@ -40,7 +40,7 @@ unsigned long compressData(const VectorXd &snpData, unsigned char *outputBuffer,
         return 0;
 
     // Compress the data
-    const unsigned int inputSize = static_cast<unsigned int>(snpData.size()) * sizeof(float);
+    const unsigned int inputSize = static_cast<unsigned int>(snpData.size()) * sizeof(double);
     strm.avail_in = inputSize;
     strm.next_in = reinterpret_cast<unsigned char *>(const_cast<double*>(&snpData[0]));
     strm.avail_out = static_cast<unsigned int>(outputSize);


### PR DESCRIPTION
The compression algorithm was still using `sizeof(float)` to calculate
the size of the data to be compressed. This meant that the compressed
data files only contained half of the processed data.