### PR TITLE
Async bayes

### DIFF
--- a/src/BayesRRmz.cpp
+++ b/src/BayesRRmz.cpp
@@ -255,7 +255,7 @@ void BayesRRmz::processColumn(unsigned int marker, const Map<VectorXd> &Cx)
     // Now epsilon contains Y-mu - X*beta + X.col(marker) * beta(marker)_old - X.col(marker) * beta(marker)_new
 }
 
-void BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx)
+double BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx)
 {
     // Lock and take local copies of needed variabls
     // [*] m_beta(marker) rwr - used, updated, then used - per column, could take a copy and update at end
@@ -399,6 +399,13 @@ void BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx)
     // These updates do not need to be atomic
     m_beta(marker) = beta;
     m_components(marker) = component;
+
+    return beta;
+}
+
+void BayesRRmz::updateGlobal(unsigned int marker, const Map<VectorXd> &Cx)
+{
+    // Update global epsilon...
 }
 
 void BayesRRmz::printDebugInfo() const

--- a/src/BayesRRmz.cpp
+++ b/src/BayesRRmz.cpp
@@ -68,6 +68,7 @@ void BayesRRmz::init(int K, unsigned int markerCount, unsigned int individualCou
     m_beta = VectorXd(markerCount);           // effect sizes
     m_y_tilde = VectorXd(individualCount);    // variable containing the adjusted residuals to exclude the effects of a given marker
     m_epsilon = VectorXd(individualCount);    // variable containing the residuals
+    m_async_epsilon = VectorXd(individualCount);
 
     m_y = VectorXd();
     //Cx = VectorXd();
@@ -132,6 +133,8 @@ int BayesRRmz::runGibbs()
          m_epsilon = m_epsilon.array() + m_mu;//  we substract previous value
          m_mu = m_dist.norm_rng(m_epsilon.sum() / (double)N, m_sigmaE / (double)N); //update mu
          m_epsilon = m_epsilon.array() - m_mu;// we substract again now epsilon =Y-mu-X*beta
+
+         std::memcpy(m_async_epsilon.data(), m_epsilon.data(), static_cast<size_t>(m_epsilon.size()) * sizeof(double));
 
         std::random_shuffle(markerI.begin(), markerI.end());
 
@@ -255,7 +258,7 @@ void BayesRRmz::processColumn(unsigned int marker, const Map<VectorXd> &Cx)
     // Now epsilon contains Y-mu - X*beta + X.col(marker) * beta(marker)_old - X.col(marker) * beta(marker)_new
 }
 
-double BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx)
+std::tuple<double, double> BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx)
 {
     // Lock and take local copies of needed variabls
     // [*] m_beta(marker) rwr - used, updated, then used - per column, could take a copy and update at end
@@ -291,7 +294,7 @@ double BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &C
         // std::memcpy is faster than epsilon = m_epsilon which compiles down to a loop over pairs of
         // doubles and uses _mm_load_pd(source) SIMD intrinsics. Just be careful if we change the type
         // contained in the vector back to floats.
-        std::memcpy(y_tilde.data(), m_epsilon.data(), static_cast<size_t>(epsilon.size()) * sizeof(double));
+        std::memcpy(y_tilde.data(), m_async_epsilon.data(), static_cast<size_t>(epsilon.size()) * sizeof(double));
         beta = m_beta(marker);
         component = m_components(marker);
     }
@@ -390,7 +393,7 @@ double BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &C
         // Use a unique lock to ensure only one thread can write updates
         std::unique_lock lock(m_mutex);
         if (!skipUpdate) {
-            std::memcpy(m_epsilon.data(), y_tilde.data(), static_cast<size_t>(y_tilde.size()) * sizeof(double));
+            std::memcpy(m_async_epsilon.data(), y_tilde.data(), static_cast<size_t>(y_tilde.size()) * sizeof(double));
             m_betasqn += beta * beta - beta_old * beta_old;
         }
         m_v += v;
@@ -400,12 +403,13 @@ double BayesRRmz::processColumnAsync(unsigned int marker, const Map<VectorXd> &C
     m_beta(marker) = beta;
     m_components(marker) = component;
 
-    return beta;
+    return {beta_old, beta};
 }
 
-void BayesRRmz::updateGlobal(unsigned int marker, const Map<VectorXd> &Cx)
+void BayesRRmz::updateGlobal(double beta_old, double beta, const Map<VectorXd> &Cx)
 {
-    // Update global epsilon...
+    // No mutex required here whilst m_globalComputeNode uses the serial policy
+    m_epsilon -= Cx * (beta - beta_old);
 }
 
 void BayesRRmz::printDebugInfo() const

--- a/src/BayesRRmz.hpp
+++ b/src/BayesRRmz.hpp
@@ -60,6 +60,7 @@ class BayesRRmz
     VectorXd m_beta;       // effect sizes
     VectorXd m_y_tilde;    // variable containing the adjusted residuals to exclude the effects of a given marker
     VectorXd m_epsilon;    // variable containing the residuals
+    VectorXd m_async_epsilon;
     double m_betasqn = 0.0;
 
     VectorXd m_y;
@@ -73,8 +74,8 @@ public:
     virtual ~BayesRRmz();
     int runGibbs(); // where we run Gibbs sampling over the parametrised model
     void processColumn(unsigned int marker, const Map<VectorXd> &Cx);
-    double processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx);
-    void updateGlobal(unsigned int marker, const Map<VectorXd> &Cx);
+    std::tuple<double, double> processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx);
+    void updateGlobal(double beta_old, double beta, const Map<VectorXd> &Cx);
 
     void setDebugEnabled(bool enabled) { m_showDebug = enabled; }
     bool isDebugEnabled() const { return m_showDebug; }

--- a/src/BayesRRmz.hpp
+++ b/src/BayesRRmz.hpp
@@ -73,7 +73,8 @@ public:
     virtual ~BayesRRmz();
     int runGibbs(); // where we run Gibbs sampling over the parametrised model
     void processColumn(unsigned int marker, const Map<VectorXd> &Cx);
-    void processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx);
+    double processColumnAsync(unsigned int marker, const Map<VectorXd> &Cx);
+    void updateGlobal(unsigned int marker, const Map<VectorXd> &Cx);
 
     void setDebugEnabled(bool enabled) { m_showDebug = enabled; }
     bool isDebugEnabled() const { return m_showDebug; }

--- a/src/parallelgraph.cpp
+++ b/src/parallelgraph.cpp
@@ -40,7 +40,7 @@ ParallelGraph::ParallelGraph(BayesRRmz *bayes, size_t maxParallel)
 
         std::get<0>(outputPorts).try_put(continue_msg());
 
-        if (input.old_beta != 0.0 && input.beta != 0.0) {
+        if (input.old_beta != 0.0 || input.beta != 0.0) {
             // Do global computation
             std::get<1>(outputPorts).try_put(std::move(input));
         } else {

--- a/src/parallelgraph.hpp
+++ b/src/parallelgraph.hpp
@@ -38,6 +38,7 @@ private:
         using DataPtr = std::shared_ptr<unsigned char[]>;
         DataPtr data = nullptr;
 
+        double old_beta = 0.0;
         double beta = 0.0;
     };
 

--- a/src/parallelgraph.hpp
+++ b/src/parallelgraph.hpp
@@ -23,15 +23,32 @@ public:
 
 private:
     struct Message {
-        unsigned int id;
-        unsigned int marker;
-        unsigned int numInds;
+        Message(unsigned int id = 0, unsigned int marker = 0, unsigned int numInds = 0)
+            : id(id)
+            , marker(marker)
+            , numInds(numInds)
+        {
+
+        }
+
+        unsigned int id = 0;
+        unsigned int marker = 0;
+        unsigned int numInds = 0;
+
+        using DataPtr = std::shared_ptr<unsigned char[]>;
+        DataPtr data = nullptr;
+
+        double beta = 0.0;
     };
 
     std::unique_ptr<graph> m_graph;
-    std::unique_ptr<function_node<Message>> m_computeNode;
+    std::unique_ptr<function_node<Message, Message>> m_asyncComputeNode;
     std::unique_ptr<limiter_node<Message>> m_limit;
     std::unique_ptr<sequencer_node<Message>> m_ordering;
+
+    using decision_node = multifunction_node<Message, tbb::flow::tuple<continue_msg, Message> >;
+    std::unique_ptr<decision_node> m_decisionNode;
+    std::unique_ptr<function_node<Message>> m_globalComputeNode;
 };
 
 #endif // PARALLELGRAPH_H


### PR DESCRIPTION
This pull request is a bit of a work in progress, and is mainly to aid discussion about the code.

The first commit adds a new section to the ParallelGraph which provides the functionality described as `worker_e` in the first proposal. `beta` and `old_beta` are returned from `BayesRRmz::processColumnAsync` and passed along the flow graph with the column data. If `beta` and `old_beta` are zero, the message is discarded and a new `m_asyncComputeNode` (worker_b) is triggered. If the beta values are not zero, the message is passed on to a `m_globalComputeNode` which updates the global epsilon `m_epsilon`.

The `BayesRRmz::processColumnAsync` now updates a new member variable `m_async_epsilon`. This member variable is reset to the value of `m_epsilon` before each run of the parallel graph.

The algorithm no longer estimates heritability:
[test.pdf](https://github.com/ctggroup/BayesRRcmd/files/2952561/test.pdf)

Nor does it converge; `--threads 8`:
[test_uk10k_chr1_1mb_varG-async.pdf](https://github.com/ctggroup/BayesRRcmd/files/2952563/test_uk10k_chr1_1mb_varG-async.pdf)

`--threads 1`:
[test_uk10k_chr1_1mb_varG-async.pdf](https://github.com/ctggroup/BayesRRcmd/files/2952571/test_uk10k_chr1_1mb_varG-async.pdf)

