### PR TITLE
Control number of threads spawned

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "BayesRRmz.hpp"
 #include "data.hpp"
 #include "options.hpp"
+#include "tbb/task_scheduler_init.h"
 
 using namespace std;
 
@@ -85,6 +86,10 @@ int main(int argc, const char * argv[]) {
                 clock_t end = clock();
                 printf("Finished reading preprocessed bed file in %.3f sec.\n", double(end - start_bed) / double(CLOCKS_PER_SEC));
                 cout << endl;
+
+                std::unique_ptr<tbb::task_scheduler_init> taskScheduler { nullptr };
+                if (opt.numThreadSpawned > 0)
+                    taskScheduler = std::make_unique<tbb::task_scheduler_init>(opt.numThreadSpawned);
 
                 BayesRRmz analysis(data, opt);
                 analysis.runGibbs();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -98,6 +98,10 @@ void Options::inputOptions(const int argc, const char* argv[]){
             numThread = atoi(argv[++i]);
             ss << "--thread " << argv[i] << "\n";
         }
+        else if(!strcmp(argv[i], "--thread-spawned")) {
+            numThreadSpawned = atoi(argv[++i]);
+            ss << "--thread-spawned " << argv[i] << "\n";
+        }
         else {
             stringstream errmsg;
             errmsg << "\nError: invalid option \"" << argv[i] << "\".\n";

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -23,6 +23,7 @@ public:
     unsigned burnin;
     unsigned seed;
     unsigned numThread;
+    int numThreadSpawned = 0; // Default to 0, let TBB do its thing
     unsigned thin;  // save every this th sampled value in MCMC
     vector<float> S;    //variance components
 
@@ -44,6 +45,7 @@ public:
         burnin                  = 5000;
         seed                    = static_cast<unsigned int>(std::time(0));
         numThread               = 1;
+        numThreadSpawned        = 0;
         thin                    = 5;
 
         S.resize(3);


### PR DESCRIPTION
Pass --thread-spawned n to allow TBB to spawn n threads. The default
value is 0, which lets TBB automatically determin the number of threads
that should be spawned.

Note that --thread still controls the parallelisation of the algorithms.