### PR TITLE
Preprocess uncompressed data

### DIFF
--- a/src/BayesRBase.cpp
+++ b/src/BayesRBase.cpp
@@ -44,12 +44,22 @@ IndexEntry BayesRBase::indexEntry(unsigned int i) const
     return m_data->ppbedIndex[i];
 }
 
+bool BayesRBase::compressed() const
+{
+    return m_opt.compress;
+}
+
 unsigned char* BayesRBase::compressedData() const
 {
     if (!m_data)
         return nullptr;
 
     return reinterpret_cast<unsigned char*>(m_data->ppBedMap);
+}
+
+std::string BayesRBase::preprocessedFile() const
+{
+    return ppFileForType(m_opt.dataType, m_opt.bedFile);
 }
 
 void BayesRBase::init(int K, unsigned int markerCount, unsigned int individualCount)

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -28,8 +28,10 @@ public:
     virtual ~BayesRBase();
 
     virtual MarkerBuilder* markerBuilder() const = 0;
-    IndexEntry indexEntry(unsigned int i) const;
-    unsigned char* compressedData() const;
+    virtual IndexEntry indexEntry(unsigned int i) const;
+    virtual bool compressed() const;
+    virtual unsigned char* compressedData() const;
+    virtual std::string preprocessedFile() const;
 
     int runGibbs(AnalysisGraph* analysis); // where we run Gibbs sampling over the parametrised model
 

--- a/src/densemarker.cpp
+++ b/src/densemarker.cpp
@@ -52,7 +52,6 @@ std::streamsize DenseMarker::size() const
 
 void DenseMarker::read(std::istream *inStream)
 {
-    // Untested - this isn't called yet
     inStream->read(reinterpret_cast<char *>(buffer.get()),
                    size());
 }

--- a/src/eigensparsemarker.cpp
+++ b/src/eigensparsemarker.cpp
@@ -52,9 +52,9 @@ void EigenSparseMarker::write(std::ostream *outStream) const
 
     SparseMarker::write(outStream);
 
-    const auto count = Zg.nonZeros();
+    const Eigen::Index count = Zg.nonZeros();
     outStream->write(reinterpret_cast<const char *>(&count),
-                     sizeof(count));
+                     sizeof(Eigen::Index));
 
     if (count > 0) {
         outStream->write(reinterpret_cast<const char *>(Zg.valuePtr()),

--- a/src/limitsequencegraph.cpp
+++ b/src/limitsequencegraph.cpp
@@ -15,8 +15,12 @@ LimitSequenceGraph::LimitSequenceGraph(size_t maxParallel)
     auto f = [this] (Message msg) -> Message {
         std::unique_ptr<MarkerBuilder> builder{m_bayes->markerBuilder()};
         builder->initialise(msg.snp, msg.numInds);
-        builder->decompress(m_bayes->compressedData(),
-                            m_bayes->indexEntry(msg.snp));
+        const auto index = m_bayes->indexEntry(msg.snp);
+        if (m_bayes->compressed()) {
+            builder->decompress(m_bayes->compressedData(), index);
+        } else {
+            builder->read(m_bayes->preprocessedFile(), index);
+        }
         msg.marker.reset(builder->build());
         return msg;
     };

--- a/src/markerbuilder.cpp
+++ b/src/markerbuilder.cpp
@@ -1,5 +1,6 @@
 #include "markerbuilder.h"
 
+#include <fstream>
 #include <iostream>
 
 MarkerBuilder::~MarkerBuilder()
@@ -12,6 +13,21 @@ void MarkerBuilder::initialise(const unsigned int snp,
 {
     reset(numInds);
     m_snp = snp;
+}
+
+void MarkerBuilder::read(const std::string &file, const IndexEntry &index) const
+{
+    assert(m_marker);
+
+    std::ifstream inStream(file.c_str(), std::ios::binary);
+    if (!inStream) {
+        std::cerr << "MarkerBuilder::read cannot read from: " << file << std::endl;
+        return;
+    }
+
+    inStream.seekg(static_cast<std::streamsize>(index.pos));
+
+    m_marker->read(&inStream);
 }
 
 void MarkerBuilder::decompress(unsigned char *data, const IndexEntry &index) const

--- a/src/markerbuilder.h
+++ b/src/markerbuilder.h
@@ -22,6 +22,8 @@ public:
 
     virtual void endColumn() = 0;
 
+    virtual void read(const std::string &file, const IndexEntry &index) const;
+
     virtual void decompress(unsigned char *data,
                             const IndexEntry &index) const;
 

--- a/src/parallelgraph.cpp
+++ b/src/parallelgraph.cpp
@@ -16,8 +16,12 @@ ParallelGraph::ParallelGraph(size_t maxParallel)
         // Decompress the column
         std::unique_ptr<MarkerBuilder> builder{m_bayes->markerBuilder()};
         builder->initialise(msg.snp, msg.numInds);
-        builder->decompress(m_bayes->compressedData(),
-                            m_bayes->indexEntry(msg.snp));
+        const auto index = m_bayes->indexEntry(msg.snp);
+        if (m_bayes->compressed()) {
+            builder->decompress(m_bayes->compressedData(), index);
+        } else {
+            builder->read(m_bayes->preprocessedFile(), index);
+        }
         msg.marker.reset(builder->build());
 
         // Delegate the processing of this column to the algorithm class

--- a/src/preprocessgraph.cpp
+++ b/src/preprocessgraph.cpp
@@ -94,6 +94,15 @@ PreprocessGraph::PreprocessGraph(size_t maxParallel)
                     continue;
 
                 dataPtr->write(m_output.get());
+
+                m_indexOutput->write(reinterpret_cast<char *>(&m_position),
+                                     sizeof(unsigned long));
+                const auto size = static_cast<unsigned long>(dataPtr->size());
+                m_indexOutput->write(reinterpret_cast<const char *>(&size),
+                                  sizeof(unsigned long));
+                m_indexOutput->write(reinterpret_cast<const char *>(&size),
+                                  sizeof(unsigned long));
+                m_position += size;
             }
         } else {
             std::for_each(msg.compressedSnpData.cbegin(),
@@ -189,12 +198,10 @@ void PreprocessGraph::preprocessBedFile(const std::string &bedFile,
         return;
     }
 
-    if (compress) {
-        m_indexOutput = std::make_unique<std::ofstream>(ppIndexFile.c_str(), ios::binary);
-        if (m_indexOutput->fail()) {
-            cerr << "Error: Unable to open the preprocessed bed index file [" + ppIndexFile + "] for writing." << endl;
-            return;
-        }
+    m_indexOutput = std::make_unique<std::ofstream>(ppIndexFile.c_str(), ios::binary);
+    if (m_indexOutput->fail()) {
+        cerr << "Error: Unable to open the preprocessed bed index file [" + ppIndexFile + "] for writing." << endl;
+        return;
     }
 
     size_t msgId = 0;


### PR DESCRIPTION
PreprocessGraph can write compressed or uncompressed data to disk.

MarkerBuilder can build Markers from uncompressed data.

ParallelGraph and LimitSequenceGraph now check whether to use compressed or uncompressed data.