### PR TITLE
Preload sparse data into memory

### DIFF
--- a/src/BayesRBase.cpp
+++ b/src/BayesRBase.cpp
@@ -44,6 +44,16 @@ IndexEntry BayesRBase::indexEntry(unsigned int i) const
     return m_data->ppbedIndex[i];
 }
 
+bool BayesRBase::preloaded() const
+{
+    return m_opt.preload;
+}
+
+std::shared_ptr<Marker> BayesRBase::marker(unsigned int i) const
+{
+    return m_data->markers.at(i);
+}
+
 bool BayesRBase::compressed() const
 {
     return m_opt.compress;

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -29,6 +29,8 @@ public:
 
     virtual MarkerBuilder* markerBuilder() const = 0;
     virtual IndexEntry indexEntry(unsigned int i) const;
+    virtual bool preloaded() const;
+    virtual std::shared_ptr<Marker> marker(unsigned int i) const;
     virtual bool compressed() const;
     virtual unsigned char* compressedData() const;
     virtual std::string preprocessedFile() const;

--- a/src/data.hpp
+++ b/src/data.hpp
@@ -75,6 +75,8 @@ public:
 
 using PpBedIndex = std::vector<IndexEntry>;
 
+struct Marker;
+
 class Data {
 public:
     Data();
@@ -84,6 +86,8 @@ public:
     double *ppBedMap;
     Map<MatrixXd> mappedZ;
     PpBedIndex ppbedIndex;
+
+    std::vector<std::shared_ptr<Marker>> markers;
 
     // Original data
     MatrixXf X;              // coefficient matrix for fixed effects
@@ -131,6 +135,8 @@ public:
 
     void mapCompressedPreprocessBedFile(const string &preprocessedBedFile, const string &indexFile);
     void unmapCompressedPreprocessedBedFile();
+
+    bool loadMarkersIntoRam(const string &preprocessedBedFile, const DataType dataType, const bool compressed);
 
     void readFamFile(const string &famFile);
     void readBimFile(const string &bimFile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,8 @@ void processDenseData(Options opt) {
         cout << "Start reading preprocessed bed file: " << ppFile << endl;
         clock_t start_bed = clock();
         data.mapCompressedPreprocessBedFile(ppFile, ppIndexFile);
+        if (opt.preload)
+            cout << "Preload not supported with dense data types!" << endl;
         clock_t end = clock();
         printf("Finished reading preprocessed bed file in %.3f sec.\n", double(end - start_bed) / double(CLOCKS_PER_SEC));
         cout << endl;
@@ -159,6 +161,14 @@ void processSparseData(Options options) {
     cout << "Start reading preprocessed bed file: " << ppFile << endl;
     clock_t start_bed = clock();
     data.mapCompressedPreprocessBedFile(ppFile, ppIndexFile);
+    if (options.preload) {
+        const bool preloadSuccess = data.loadMarkersIntoRam(ppFile, options.dataType, options.compress);
+
+        if (!preloadSuccess) {
+            data.unmapCompressedPreprocessedBedFile();
+            return;
+        }
+    }
     clock_t end = clock();
     printf("Finished reading preprocessed bed file in %.3f sec.\n", double(end - start_bed) / double(CLOCKS_PER_SEC));
     cout << endl;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -117,6 +117,10 @@ void Options::inputOptions(const int argc, const char* argv[]){
             preprocessChunks = atoi(argv[++i]);
             ss << "--preprocess-chunks " << argv[i] << "\n";
         }
+        else if(!strcmp(argv[i], "--preload")) {
+            preload = true;
+            ss << "--preload " << "\n";
+        }
         else {
             stringstream errmsg;
             errmsg << "\nError: invalid option \"" << argv[i] << "\".\n";

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -42,6 +42,7 @@ public:
     string optionFile;
     bool compress = false;
     DataType dataType = DataType::Dense;
+    bool preload = false;
 
     Options(){
         chainLength             = 10000;
@@ -66,6 +67,7 @@ public:
         optionFile				= "";
         numGroups				=2;
         dataType                = DataType::Dense;
+        preload                 = false;
     }
 
     void inputOptions(const int argc, const char* argv[]);


### PR DESCRIPTION
Passing the --preload option when processing sparse data loads all the data into memory before performing an analysis.

