### PR TITLE
Improve parallel graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,16 @@
 cmake_minimum_required(VERSION 2.8.12)
+
+option(BRR_TRACE_FLOW_GRAPH "Enable flow graph tracing" OFF)
+
+if(BRR_TRACE_FLOW_GRAPH)
+    add_definitions(-DTBB_USE_THREADING_TOOLS)
+    add_definitions(-DTBB_PREVIEW_FLOW_GRAPH_TRACE)
+    add_definitions(-DTBB_PREVIEW_FLOW_GRAPH_FEATURES)
+    add_definitions(-DTBB_PREVIEW_ALGORITHM_TRACE)
+endif()
+
 add_subdirectory(src)
 
 if(TEST)
 	add_subdirectory(test)
 endif()
-	

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -22,6 +22,12 @@ class AnalysisGraph;
 struct Marker;
 class MarkerBuilder;
 
+struct AsyncResult {
+    double betaOld = 0.0;
+    double beta = 0.0;
+    VectorXd deltaEpsilon;
+};
+
 class BayesRBase
 {
 public:
@@ -38,9 +44,9 @@ public:
 
     virtual void processColumn(Marker *marker);
 
-    virtual std::tuple<double, double,VectorXd> processColumnAsync(Marker *marker);
+    virtual std::unique_ptr<AsyncResult> processColumnAsync(Marker *marker);
 
-    virtual void updateGlobal(Marker *marker, const double beta_old, const double beta,VectorXd& deltaEps) = 0;
+    virtual void updateGlobal(Marker *marker, const double beta_old, const double beta, const VectorXd& deltaEps) = 0;
     virtual void updateMu(double old_mu, double N)=0;
 
     void setDebugEnabled(bool enabled) { m_showDebug = enabled; }

--- a/src/DenseBayesRRmz.cpp
+++ b/src/DenseBayesRRmz.cpp
@@ -24,7 +24,7 @@ MarkerBuilder *DenseBayesRRmz::markerBuilder() const
     return builderForType(DataType::Dense);
 }
 
-void DenseBayesRRmz::updateGlobal(Marker *marker, const double beta_old, const double beta,VectorXd& deltaEps )
+void DenseBayesRRmz::updateGlobal(Marker *marker, const double beta_old, const double beta, const VectorXd& deltaEps)
 {
     // No mutex required here whilst m_globalComputeNode uses the serial policy
     auto* denseMarker = dynamic_cast<DenseMarker*>(marker);

--- a/src/DenseBayesRRmz.hpp
+++ b/src/DenseBayesRRmz.hpp
@@ -21,7 +21,7 @@ public:
 
     MarkerBuilder *markerBuilder() const override;
 
-  void updateGlobal(Marker *marker, const double beta_old, const double beta,VectorXd& deltaEps) override;
+  void updateGlobal(Marker *marker, const double beta_old, const double beta, const VectorXd &deltaEps) override;
   void updateMu(double old_mu,double N) override;
 
 protected:

--- a/src/SparseBayesRRG.cpp
+++ b/src/SparseBayesRRG.cpp
@@ -76,7 +76,7 @@ void SparseBayesRRG::writeWithUniqueLock(Marker *marker)
         m_epsilonSum += sparseMarker->epsilonSum;
 }
 
-void SparseBayesRRG::updateGlobal(Marker *marker, const double beta_old, const double beta,VectorXd& deltaEps)
+void SparseBayesRRG::updateGlobal(Marker *marker, const double beta_old, const double beta, const VectorXd& deltaEps)
 {
     // No mutex required here whilst m_globalComputeNode uses the serial policy
     auto* sparseMarker = dynamic_cast<SparseMarker*>(marker);

--- a/src/SparseBayesRRG.hpp
+++ b/src/SparseBayesRRG.hpp
@@ -15,7 +15,7 @@ public:
 
     MarkerBuilder *markerBuilder() const override;
 
-  void updateGlobal(Marker *marker, const double beta_old, const double beta,VectorXd& deltaEps ) override;
+  void updateGlobal(Marker *marker, const double beta_old, const double beta, const VectorXd &deltaEps ) override;
    void updateMu(double old_mu,double N);
 protected:
     double m_asyncEpsilonSum = 0.0;

--- a/src/analysisgraph.hpp
+++ b/src/analysisgraph.hpp
@@ -9,7 +9,7 @@ class BayesRBase;
 class AnalysisGraph
 {
 public:
-    AnalysisGraph(size_t maxParallel = 12);
+    AnalysisGraph(size_t maxParallel = 0);
     virtual ~AnalysisGraph();
 
     // Return true if the analysis calls BayesRBase::processColumnAsync
@@ -22,7 +22,7 @@ public:
 
 protected:
     BayesRBase *m_bayes = nullptr;
-    size_t m_maxParallel = 12;
+    size_t m_maxParallel = 0; // Default to tbb::flow::unlimited
 };
 
 #endif // ANALYSISGRAPH_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,7 +96,10 @@ void processDenseData(Options opt) {
 
         std::unique_ptr<AnalysisGraph> graph {nullptr};
         if (opt.analysisType == "PPAsyncBayes") {
-            graph = std::make_unique<ParallelGraph>(opt.numThread);
+            graph = std::make_unique<ParallelGraph>(opt.decompressionTokens, opt.analysisTokens);
+            auto *parallelGraph = dynamic_cast<ParallelGraph*>(graph.get());
+            parallelGraph->setDecompressionNodeConcurrency(opt.decompressionNodeConcurrency);
+            parallelGraph->setAnalysisNodeConcurrency(opt.analysisNodeConcurrency);
         } else {
             graph = std::make_unique<LimitSequenceGraph>(opt.numThread);
         }
@@ -169,7 +172,10 @@ void processSparseData(Options options) {
 
     std::unique_ptr<AnalysisGraph> graph {nullptr};
     if (options.analysisType == "PPAsyncBayes") {
-        graph = std::make_unique<ParallelGraph>(options.numThread);
+        graph = std::make_unique<ParallelGraph>(options.decompressionTokens, options.analysisTokens);
+        auto *parallelGraph = dynamic_cast<ParallelGraph*>(graph.get());
+        parallelGraph->setDecompressionNodeConcurrency(options.decompressionNodeConcurrency);
+        parallelGraph->setAnalysisNodeConcurrency(options.analysisNodeConcurrency);
     } else {
         graph = std::make_unique<LimitSequenceGraph>(options.numThread);
     }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -113,6 +113,22 @@ void Options::inputOptions(const int argc, const char* argv[]){
             numThreadSpawned = atoi(argv[++i]);
             ss << "--thread-spawned " << argv[i] << "\n";
         }
+        else if(!strcmp(argv[i], "--decompression-concurrency")) {
+            decompressionNodeConcurrency = atoi(argv[++i]);
+            ss << "--decompression-concurrency " << argv[i] << "\n";
+        }
+        else if(!strcmp(argv[i], "--decompression-tokens")) {
+            decompressionTokens = atoi(argv[++i]);
+            ss << "--decompression-tokens " << argv[i] << "\n";
+        }
+        else if(!strcmp(argv[i], "--analysis-concurrency")) {
+            analysisNodeConcurrency = atoi(argv[++i]);
+            ss << "--analysis-concurrency " << argv[i] << "\n";
+        }
+        else if(!strcmp(argv[i], "--analysis-tokens")) {
+            analysisTokens = atoi(argv[++i]);
+            ss << "--analysis-tokens " << argv[i] << "\n";
+        }
         else if(!strcmp(argv[i], "--preprocess-chunks")) {
             preprocessChunks = atoi(argv[++i]);
             ss << "--preprocess-chunks " << argv[i] << "\n";

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -25,6 +25,10 @@ public:
     unsigned seed;
     unsigned numThread;
     int numThreadSpawned = 0; // Default to 0, let TBB do its thing
+    size_t decompressionNodeConcurrency = 0;
+    size_t decompressionTokens = 40;
+    size_t analysisNodeConcurrency = 0;
+    size_t analysisTokens = 20;
     unsigned preprocessChunks = 1;
     unsigned thin;  // save every this th sampled value in MCMC
     vector<float> S;    //variance components
@@ -53,6 +57,10 @@ public:
         seed                    = static_cast<unsigned int>(std::time(0));
         numThread               = 1;
         numThreadSpawned        = 0;
+        decompressionNodeConcurrency = 0;
+        decompressionTokens     = 40;
+        analysisNodeConcurrency = 0;
+        analysisTokens          = 20;
         preprocessChunks        = 1;
         thin                    = 5;
 

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -23,7 +23,7 @@ public:
     unsigned chainLength;
     unsigned burnin;
     unsigned seed;
-    unsigned numThread;
+    unsigned numThread = 0; // Default to tbb::flow::unlimited
     int numThreadSpawned = 0; // Default to 0, let TBB do its thing
     size_t decompressionNodeConcurrency = 0;
     size_t decompressionTokens = 40;
@@ -55,7 +55,7 @@ public:
         chainLength             = 10000;
         burnin                  = 5000;
         seed                    = static_cast<unsigned int>(std::time(0));
-        numThread               = 1;
+        numThread               = 0;
         numThreadSpawned        = 0;
         decompressionNodeConcurrency = 0;
         decompressionTokens     = 40;

--- a/src/parallelgraph.cpp
+++ b/src/parallelgraph.cpp
@@ -7,99 +7,118 @@
 
 #include <iostream>
 
-ParallelGraph::ParallelGraph(size_t maxParallel)
-    : AnalysisGraph(maxParallel)
+ParallelGraph::ParallelGraph(size_t maxDecompressionTokens, size_t maxAnalysisTokens)
+    : AnalysisGraph()
     , m_graph(new graph)
+    , m_decompressionTokens(maxDecompressionTokens)
+    , m_analysisTokens(maxAnalysisTokens)
 {
+    m_decompressionJoinNode.reset(new decompression_join_node(*m_graph));
+
     // Decompress the column for this marker then process the column using the algorithm class
-    auto f = [this] (Message msg) -> Message {
-      // Decompress the column
-      std::unique_ptr<MarkerBuilder> builder{m_bayes->markerBuilder()};
-      builder->initialise(msg.snp, msg.numInds);
-      const auto index = m_bayes->indexEntry(msg.snp);
-      if (m_bayes->compressed()) {
+    auto f = [this] (DecompressionTuple tuple) -> DecompressionTuple {
+        auto &msg = std::get<1>(tuple);
+        // Decompress the column
+        std::unique_ptr<MarkerBuilder> builder{m_bayes->markerBuilder()};
+        builder->initialise(msg.snp, msg.numInds);
+        const auto index = m_bayes->indexEntry(msg.snp);
+        if (m_bayes->compressed()) {
             builder->decompress(m_bayes->compressedData(), index);
         } else {
             builder->read(m_bayes->preprocessedFile(), index);
-          }
-      msg.marker.reset(builder->build());
-      return msg;
-      };
-
-    // Do the decompression work on up to maxParallel threads at once
-    m_decompressNode.reset(new function_node<Message, Message>(*m_graph, m_decompressSize, f));
-
-    // The sequencer node enforces the correct ordering based upon the message id
-    m_ordering.reset(new sequencer_node<Message>(*m_graph, [] (const Message& msg) -> unsigned int {
-      return msg.id;
-      }));
-
-    // Sampling of the column to the async algorithm class
-    auto g = [this] (Message msg) -> Message {
-      msg.result = m_bayes->processColumnAsync(msg.marker.get());
-      return msg;
+        }
+        msg.marker.reset(builder->build());
+        return tuple;
     };
 
-    // Sample in parallel but with a variable maxParallel2
-    m_asyncSamplingNode.reset(new function_node<Message, Message>(*m_graph, m_maxParallel, g));
+    m_decompressionNode.reset(new decompression_node(*m_graph,
+                                                     m_decompressionNodeConcurrency,
+                                                     f));
+
+    m_analysisJoinNode.reset(new analysis_join_node(*m_graph));
+
+    // Sampling of the column to the async algorithm class
+    auto g = [this] (AnalysisTuple tuple) -> AnalysisTuple {
+        auto &msg = std::get<1>(std::get<1>(tuple));
+        msg.result = m_bayes->processColumnAsync(msg.marker.get());
+        return tuple;
+    };
+
+    m_analysisNode.reset(new analysis_node(*m_graph, m_analysisNodeConcurrency, g));
 
     // Decide whether to continue calculations or discard
     auto h = [] (decision_node::input_type input,
-                decision_node::output_ports_type &outputPorts) {
+            decision_node::output_ports_type &outputPorts) {
 
-      std::get<0>(outputPorts).try_put(continue_msg());
+        auto &decompressionTuple = std::get<1>(input);
+        auto &msg = std::get<1>(decompressionTuple);
 
-      if (input.result->betaOld != 0.0 || input.result->beta != 0.0) {
-         // Do global computation
-         std::get<1>(outputPorts).try_put(std::move(input));
-         } else {
-         // Discard
-         std::get<0>(outputPorts).try_put(continue_msg());
-         }
-      };
+        if (msg.result->betaOld != 0.0 || msg.result->beta != 0.0) {
+            // Do global computation
+            std::get<2>(outputPorts).try_put(input);
+        } else {
+            // Discard
+            std::get<0>(outputPorts).try_put(std::get<0>(decompressionTuple));
+            std::get<1>(outputPorts).try_put(std::get<0>(input));
+        }
+    };
 
-    m_decisionNode.reset(new decision_node(*m_graph, m_maxParallel, h));
-
+    m_decisionNode.reset(new decision_node(*m_graph, unlimited, h));
 
     // Do global computation
-    auto i = [this] (Message msg) -> continue_msg {
-      m_bayes->updateGlobal(msg.marker.get(), msg.result->betaOld, msg.result->beta, msg.result->deltaEpsilon);
-      return continue_msg();
-      };
-    // Use the serial policy
-    m_globalComputeNode.reset(new function_node<Message>(*m_graph, serial, i));
+    auto i = [this] (global_update_node::input_type input,
+            global_update_node::output_ports_type &outputPorts) {
 
-    // Limit the number of sampler
-    m_limit.reset(new limiter_node<Message>(*m_graph, m_limitSize));
+        auto &decompressionTuple = std::get<1>(input);
+        auto &msg = std::get<1>(decompressionTuple);
+
+        m_bayes->updateGlobal(msg.marker.get(),
+                              msg.result->betaOld,
+                              msg.result->beta,
+                              msg.result->deltaEpsilon);
+
+        std::get<0>(outputPorts).try_put(std::get<0>(decompressionTuple));
+        std::get<1>(outputPorts).try_put(std::get<0>(input));
+    };
+    // Use the serial policy
+    m_globalUpdateNode.reset(new global_update_node(*m_graph, serial, i));
+
+    // Force synchronisation after m_anaylsisToken analyses
+    auto j = [this](AnalysisToken t) -> continue_msg {
+        (void) t; // Unused
+        --m_analysisTokenCount;
+
+        if (m_analysisTokenCount == 0) {
+            // Allow the next set of analyses to take place
+            queueAnalysisTokens();
+        }
+
+        return continue_msg();
+    };
+    m_analysisControlNode.reset(new analysis_control_node(*m_graph, serial, j));
 
 
     // Set up the graph topology:
-    //
-    // orderingNode -> decompressionNode (parallel)
-    //                            |
-    //                            |
-    //  limitNode (serial) -> samplingNode (parallel)
-    //        ^                   |
-    //        |                   |
-    //        |______________ decisionNode (parallel)
-    //        |                   |
-    //        |                   | keep
-    //        |                   |
-    //        |______________globalCompute (serial)
-    //
-    // Run the decompressionAndSampling node in the correct order, but do not
-    // wait for the most up-to-date data.
-    make_edge(*m_limit,*m_asyncSamplingNode);
-    make_edge(*m_ordering, *m_decompressNode);
-    make_edge(*m_decompressNode, *m_asyncSamplingNode);
-    make_edge(*m_asyncSamplingNode, *m_decisionNode);
-    // Feedback that we can now sample more columns, OR
-    make_edge(output_port<0>(*m_decisionNode), m_limit->decrement);
-    // pass to the global computation
-    make_edge(output_port<1>(*m_decisionNode), *m_globalComputeNode);
+#if defined(TBB_PREVIEW_FLOW_GRAPH_TRACE)
+    m_graph->set_name("ParallelGraph");
+    m_analysisNode->set_name("analysis_node");
+    m_decisionNode->set_name("decision_node");
+    m_globalUpdateNode->set_name("global_update_node");
+    m_decompressionJoinNode->set_name("decompression_join_node");
+    m_decompressionNode->set_name("decompression_node");
+    m_analysisJoinNode->set_name("analysis_join_node");
+    m_analysisControlNode->set_name("analysis_control_node");
+#endif
 
-    // Feedback that we can now sample more columns
-    make_edge(*m_globalComputeNode, m_limit->decrement);
+    make_edge(*m_decompressionJoinNode, *m_decompressionNode);
+    make_edge(*m_decompressionNode, input_port<1>(*m_analysisJoinNode));
+    make_edge(*m_analysisJoinNode, *m_analysisNode);
+    make_edge(*m_analysisNode, *m_decisionNode);
+    make_edge(output_port<0>(*m_decisionNode), input_port<0>(*m_decompressionJoinNode));
+    make_edge(output_port<1>(*m_decisionNode), *m_analysisControlNode);
+    make_edge(output_port<2>(*m_decisionNode), *m_globalUpdateNode);
+    make_edge(output_port<0>(*m_globalUpdateNode), input_port<0>(*m_decompressionJoinNode));
+    make_edge(output_port<1>(*m_globalUpdateNode), *m_analysisControlNode);
 }
 
 void ParallelGraph::exec(BayesRBase *bayes,
@@ -119,13 +138,15 @@ void ParallelGraph::exec(BayesRBase *bayes,
     const auto eigenThreadCount = Eigen::nbThreads();
     Eigen::setNbThreads(0);
 
-    // Reset the graph from the previous iteration. This resets the sequencer node current index etc.
+    // Reset the graph from the previous iteration.
     m_graph->reset();
+    queueDecompressionTokens();
+    queueAnalysisTokens();
 
     // Push some messages into the top of the graph to be processed - representing the column indices
     for (unsigned int i = 0; i < numSnps; ++i) {
         Message msg = { i, markerIndices[i], numInds };
-        m_ordering->try_put(msg);
+        input_port<1>(*m_decompressionJoinNode).try_put(msg);
     }
 
     // Wait for the graph to complete
@@ -136,4 +157,58 @@ void ParallelGraph::exec(BayesRBase *bayes,
 
     // Clean up
     m_bayes = nullptr;
+}
+
+size_t ParallelGraph::decompressionNodeConcurrency() const
+{
+    return m_decompressionNodeConcurrency;
+}
+
+void ParallelGraph::setDecompressionNodeConcurrency(size_t c)
+{
+    m_decompressionNodeConcurrency = c;
+}
+
+size_t ParallelGraph::decompressionTokens() const
+{
+    return m_decompressionTokens;
+}
+
+void ParallelGraph::setDecompressionTokens(size_t t)
+{
+    m_decompressionTokens = t;
+}
+
+size_t ParallelGraph::analysisNodeConcurrency() const
+{
+    return m_analysisNodeConcurrency;
+}
+
+void ParallelGraph::setAnalysisNodeConcurrency(size_t c)
+{
+    m_analysisNodeConcurrency = c;
+}
+
+size_t ParallelGraph::analysisTokens() const
+{
+    return m_analysisTokens;
+}
+
+void ParallelGraph::setAnalysisTokens(size_t t)
+{
+    m_analysisTokens = t;
+}
+
+void ParallelGraph::queueDecompressionTokens()
+{
+    for(DecompressionToken t = 0; t < m_decompressionTokens; ++t)
+        input_port<0>(*m_decompressionJoinNode).try_put(t);
+}
+
+void ParallelGraph::queueAnalysisTokens()
+{
+    for(AnalysisToken t = 0; t < m_analysisTokens; ++t)
+        input_port<0>(*m_analysisJoinNode).try_put(t);
+
+    m_analysisTokenCount = m_analysisTokens;
 }

--- a/src/parallelgraph.h
+++ b/src/parallelgraph.h
@@ -13,12 +13,15 @@ class BayesRBase;
 struct Marker;
 struct AsyncResult;
 
+using DecompressionToken = size_t;
+using AnalysisToken = size_t;
+
 using namespace tbb::flow;
 
 class ParallelGraph : public AnalysisGraph
 {
 public:
-    explicit ParallelGraph(size_t maxParallel = 6);
+    explicit ParallelGraph(size_t decompressionTokens, size_t analysisTokens);
 
     bool isAsynchronous() const override { return true; }
 
@@ -26,6 +29,22 @@ public:
               unsigned int numKeptInds,
               unsigned int numIncdSnps,
               const std::vector<unsigned int> &markerIndices) override;
+
+    // The maximum number of decompression_node bodies which can run concurrently
+    size_t decompressionNodeConcurrency() const;
+    void setDecompressionNodeConcurrency(size_t c);
+
+    // The maximum number of decompressed messages in memory
+    size_t decompressionTokens() const;
+    void setDecompressionTokens(size_t t);
+
+    // The maximum number of analysis_node bodies which can run concurrently
+    size_t analysisNodeConcurrency() const;
+    void setAnalysisNodeConcurrency(size_t c);
+
+    // The number of asynchronous analyses to do before forcing synchronisation
+    size_t analysisTokens() const;
+    void setAnalysisTokens(size_t t);
 
 private:
     struct Message {
@@ -36,17 +55,41 @@ private:
         std::shared_ptr<const AsyncResult> result = nullptr;
     };
 
-    std::unique_ptr<graph> m_graph;
-    std::unique_ptr<function_node<Message, Message>> m_decompressNode;
-    std::unique_ptr<function_node<Message, Message>> m_asyncSamplingNode;
-    std::unique_ptr<limiter_node<Message>> m_limit;
-    std::unique_ptr<sequencer_node<Message>> m_ordering;
+    using DecompressionTuple = tbb::flow::tuple<DecompressionToken, Message>;
+    using AnalysisTuple = tbb::flow::tuple<AnalysisToken, DecompressionTuple>;
 
-    using decision_node = multifunction_node<Message, tbb::flow::tuple<continue_msg, Message> >;
+    std::unique_ptr<graph> m_graph;
+
+    using decompression_join_node = join_node<DecompressionTuple, queueing>;
+    std::unique_ptr<decompression_join_node> m_decompressionJoinNode;
+
+    using decompression_node = function_node<DecompressionTuple, DecompressionTuple>;
+    std::unique_ptr<decompression_node> m_decompressionNode;
+
+    using analysis_join_node = join_node<AnalysisTuple, queueing>;
+    std::unique_ptr<analysis_join_node> m_analysisJoinNode;
+
+    using analysis_node = function_node<AnalysisTuple, AnalysisTuple>;
+    std::unique_ptr<analysis_node> m_analysisNode;
+
+    using decision_node = multifunction_node<AnalysisTuple, tbb::flow::tuple<DecompressionToken, AnalysisToken, AnalysisTuple>>;
     std::unique_ptr<decision_node> m_decisionNode;
-    std::unique_ptr<function_node<Message>> m_globalComputeNode;
-    size_t m_decompressSize=20;
-    size_t m_limitSize=1;
+
+    using global_update_node = multifunction_node<AnalysisTuple, tbb::flow::tuple<DecompressionToken, AnalysisToken>>;
+    std::unique_ptr<global_update_node> m_globalUpdateNode;
+
+    using analysis_control_node = function_node<AnalysisToken, continue_msg, lightweight>;
+    std::unique_ptr<analysis_control_node> m_analysisControlNode;
+
+    size_t m_decompressionNodeConcurrency = tbb::flow::unlimited;
+    size_t m_decompressionTokens = 40;
+
+    size_t m_analysisNodeConcurrency = tbb::flow::unlimited;
+    size_t m_analysisTokens = 20;
+    size_t m_analysisTokenCount = 0;
+
+    void queueDecompressionTokens();
+    void queueAnalysisTokens();
 };
 
 #endif // DENSEPARALLELGRAPH_H

--- a/src/parallelgraph.h
+++ b/src/parallelgraph.h
@@ -11,6 +11,7 @@
 class BayesRBase;
 
 struct Marker;
+struct AsyncResult;
 
 using namespace tbb::flow;
 
@@ -32,9 +33,7 @@ private:
         unsigned int snp = 0;
         unsigned int numInds = 0;
         std::shared_ptr<Marker> marker = nullptr;
-        Eigen::VectorXd deltaEps; //vector that stores the epsilon update only
-        double old_beta = 0.0;
-        double beta = 0.0;
+        std::shared_ptr<const AsyncResult> result = nullptr;
     };
 
     std::unique_ptr<graph> m_graph;


### PR DESCRIPTION
ParallelGraph now uses tokens to control the number of decompressed
markers stored in memory and the number of asynchronous analyses run
before synchronisation is forced.

Concurrency of decompression and analysis nodes can be controlled
independently, but the default is to let TBB manage this. Instead, the
synchronicity of the algorithm should be managed using tokens.

The following commandline options have been added
--decompression-concurrency <n> The maximum number of decompression_node
bodies which can run concurrently. 0 indicates unlimited concurrency.
The default value is 0.

--decompression-tokens <n> The maximum number of decompressed markers in
memory. Default value is 40.

--analysis-concurrency <n> The maximum number of analysis_node bodies
which can run concurrently. 0 indicates unlimited concurrency. The
default value is 0.

--analysis-tokens <n> The number of asynchronous analyses to do before
forcing synchronisation. Default value is 20.