### PR TITLE
Performance improvement - setZero

### DIFF
--- a/src/BayesRBase.cpp
+++ b/src/BayesRBase.cpp
@@ -84,8 +84,8 @@ void BayesRBase::init(int K, unsigned int markerCount, unsigned int individualCo
     m_sigmaE = 0.0;   // residuals variance
 
     // Linear model variables
-    m_beta = VectorXd(markerCount);           // effect sizes
-    m_y_tilde = VectorXd(individualCount);    // variable containing the adjusted residuals to exclude the effects of a given marker
+    m_beta = VectorXd::Zero(markerCount);           // effect sizes
+    m_y_tilde = VectorXd::Zero(individualCount);    // variable containing the adjusted residuals to exclude the effects of a given marker
     m_epsilon = VectorXd(individualCount);    // variable containing the residuals
 
     m_y = VectorXd();
@@ -97,11 +97,9 @@ void BayesRBase::init(int K, unsigned int markerCount, unsigned int individualCo
     m_cVa.segment(1, km1) = m_cva;
     m_priorPi[0] = 0.5;
     m_priorPi.segment(1, km1) = m_priorPi[0] * m_cVa.segment(1, km1).array() / m_cVa.segment(1, km1).sum();
-    m_y_tilde.setZero();
 
     m_cVaI[0] = 0;
     m_cVaI.segment(1, km1) = m_cVa.segment(1, km1).cwiseInverse();
-    m_beta.setZero();
     m_sigmaG = m_dist.beta_rng(1,1);
 
     m_pi = m_priorPi;
@@ -184,8 +182,7 @@ int BayesRBase::runGibbs(AnalysisGraph *analysis)
     const auto t1 = std::chrono::high_resolution_clock::now();
 
     // This for MUST NOT BE PARALLELIZED, IT IS THE MARKOV CHAIN
-    m_components.resize(M);
-    m_components.setZero();
+    m_components = VectorXd::Zero(M);
 
     long meanIterationTime = 0;
     long meanFlowGraphIterationTime = 0;
@@ -205,7 +202,7 @@ int BayesRBase::runGibbs(AnalysisGraph *analysis)
         std::random_shuffle(markerI.begin(), markerI.end());
 
         m_m0 = 0;
-        m_v.setZero();
+        m_v = VectorXd::Zero(K);
 
         // This for should not be parallelized, resulting chain would not be ergodic, still, some times it may converge to the correct solution.
         // The flow graph is constructed to allow the data to be decompressed in parallel for enforce sequential processing of each column
@@ -435,8 +432,7 @@ std::unique_ptr<AsyncResult> BayesRBase::processColumnAsync(Marker *marker)
             return m_dist.norm_rng(muk[k], m_sigmaE/denom[k-1]);
         });
     }
-    VectorXd v = VectorXd(K);
-    v.setZero();
+    VectorXd v = VectorXd::Zero(K);
     for (int k = 0; k < K; k++) {
         if (p <= acum) {
             //if zeroth component

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -25,7 +25,7 @@ class MarkerBuilder;
 struct AsyncResult {
     double betaOld = 0.0;
     double beta = 0.0;
-    VectorXd deltaEpsilon;
+    std::unique_ptr<VectorXd> deltaEpsilon;
 };
 
 class BayesRBase

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -231,7 +231,7 @@ void Data::readPhenotypeFile(const string &phenFile) {
     string id;
     unsigned line=0;
     //correct loop to go through numInds
-    y.setZero(numInds);
+    y = VectorXf::Zero(numInds);
 
     while (getline(in,inputStr)) {
         colData.getTokens(inputStr, sep);

--- a/src/densemarker.cpp
+++ b/src/densemarker.cpp
@@ -7,15 +7,14 @@
 
 double DenseMarker::computeNum(VectorXd &epsilon, const double beta_old)
 {
-  //in order to not break async and sync updates for dense we change this
-  //we now CX dot CX = N-1 given that both are already centered and scaled
-  return Cx->dot(epsilon) + beta_old * static_cast<double>(numInds-1);
+    //in order to not break async and sync updates for dense we change this
+    //we now CX dot CX = N-1 given that both are already centered and scaled
+    return Cx->dot(epsilon) + beta_old * static_cast<double>(numInds-1);
 }
 
-void DenseMarker::updateEpsilon(VectorXd &epsilon, const double beta_old, const double beta)
+VectorXdPtr DenseMarker::calculateEpsilonChange(const double beta_old, const double beta)
 {
-  //now we can go back to the old epsilon update
-    epsilon += (beta_old-beta) * *Cx;
+    return std::make_unique<VectorXd>((beta_old-beta) * *Cx);
 }
 
 CompressedMarker DenseMarker::compress() const

--- a/src/densemarker.h
+++ b/src/densemarker.h
@@ -12,9 +12,8 @@ struct DenseMarker : public Marker
     std::shared_ptr<Map<VectorXd>> Cx = nullptr;
 
     double computeNum(VectorXd &epsilon, const double beta_old) override;
-    void updateEpsilon(VectorXd &epsilon,
-                       const double beta_old,
-                       const double beta) override;
+    VectorXdPtr calculateEpsilonChange(const double beta_old,
+                                       const double beta) override;
 
     CompressedMarker compress() const override;
     void decompress(unsigned char *data, const IndexEntry &index) override;

--- a/src/eigensparsemarker.cpp
+++ b/src/eigensparsemarker.cpp
@@ -2,12 +2,11 @@
 
 #include <iostream>
 
-void EigenSparseMarker::updateEpsilon(VectorXd &epsilon, const double beta_old, const double beta)
+VectorXdPtr EigenSparseMarker::calculateEpsilonChange(const double beta_old, const double beta)
 {
-    SparseMarker::updateEpsilon(epsilon, beta_old, beta);
-
+    SparseMarker::calculateEpsilonChange(beta_old, beta);
     const double dBeta = beta_old - beta;
-    epsilon += dBeta * Zg / sd - dBeta * mean / sd * *ones;
+    return std::make_unique<VectorXd>(dBeta * Zg / sd - dBeta * mean / sd * *ones);
 }
 
 std::streamsize EigenSparseMarker::size() const

--- a/src/eigensparsemarker.h
+++ b/src/eigensparsemarker.h
@@ -10,9 +10,8 @@ struct EigenSparseMarker : public SparseMarker
 
     const VectorXd *ones = nullptr;
 
-    void updateEpsilon(VectorXd &epsilon,
-                       const double beta_old,
-                       const double beta) override;
+    VectorXdPtr calculateEpsilonChange(const double beta_old,
+                                       const double beta) override;
 
     std::streamsize size() const override;
     void read(std::istream *inStream) override;

--- a/src/marker.h
+++ b/src/marker.h
@@ -8,6 +8,8 @@
 
 using namespace Eigen;
 
+using VectorXdPtr = std::unique_ptr<VectorXd>;
+
 struct CompressedMarker
 {
     std::shared_ptr<unsigned char[]> buffer = nullptr;
@@ -24,9 +26,8 @@ struct Marker
     virtual double computeNum(VectorXd &epsilon,
                               const double beta_old) = 0;
 
-    virtual void updateEpsilon(VectorXd &epsilon,
-                               const double beta_old,
-                               const double beta) = 0;
+    virtual VectorXdPtr calculateEpsilonChange(const double beta_old,
+                                               const double beta) = 0;
 
     virtual CompressedMarker compress() const;
     virtual void decompress(unsigned char* data,

--- a/src/parallelgraph.cpp
+++ b/src/parallelgraph.cpp
@@ -75,7 +75,7 @@ ParallelGraph::ParallelGraph(size_t maxDecompressionTokens, size_t maxAnalysisTo
         m_bayes->updateGlobal(msg.marker.get(),
                               msg.result->betaOld,
                               msg.result->beta,
-                              msg.result->deltaEpsilon);
+                              *msg.result->deltaEpsilon);
 
         std::get<0>(outputPorts).try_put(std::get<0>(decompressionTuple));
         std::get<1>(outputPorts).try_put(std::get<0>(input));

--- a/src/raggedsparsemarker.cpp
+++ b/src/raggedsparsemarker.cpp
@@ -6,13 +6,10 @@ VectorXdPtr RaggedSparseMarker::calculateEpsilonChange(const double beta_old, co
 {
     SparseMarker::calculateEpsilonChange(beta_old, beta);
 
-    auto delta = std::make_unique<VectorXd>(numInds);
-    delta->setZero();
-
     const double dBeta = beta_old - beta;
     const auto meanAdjustment = dBeta * mean / sd;
     // 1. Adjust for the means. If snp is 0, this will be the only adjustment made
-    delta->array() -= meanAdjustment;
+    auto delta = std::make_unique<VectorXd>(VectorXd::Constant(numInds, -meanAdjustment));
 
     // 2. Adjust for snp 1 values
     const double oneAdjustment = dBeta / sd;

--- a/src/raggedsparsemarker.h
+++ b/src/raggedsparsemarker.h
@@ -15,9 +15,8 @@ struct RaggedSparseMarker : public SparseMarker
     // the indexes of elements of the bed matrix which are missing for this column
     IndexVector Zmissing;
 
-    void updateEpsilon(VectorXd &epsilon,
-                       const double beta_old,
-                       const double beta) override;
+    VectorXdPtr calculateEpsilonChange(const double beta_old,
+                                       const double beta) override;
 
     std::streamsize size() const override;
     void read(std::istream *inStream) override;

--- a/src/sparsemarker.cpp
+++ b/src/sparsemarker.cpp
@@ -10,11 +10,13 @@ double SparseMarker::computeNum(VectorXd &epsilon, const double beta_old)
     return computeNum(epsilon, beta_old, epsilonSum);
 }
 
-void SparseMarker::updateEpsilon(VectorXd &epsilon, const double beta_old, const double beta)
+VectorXdPtr SparseMarker::calculateEpsilonChange(const double beta_old, const double beta)
 {
-    (void) epsilon; // Used by derived types
     // now every update only saves delta epsilon sum
     epsilonSum = computeEpsilonSumUpdate(beta_old, beta);
+
+    // return nullptr because we don't calculate the epsilon change here
+    return nullptr;
 }
 
 void SparseMarker::updateStatistics(unsigned int allele1, unsigned int allele2)

--- a/src/sparsemarker.h
+++ b/src/sparsemarker.h
@@ -14,9 +14,8 @@ struct SparseMarker : public Marker
 
     double computeNum(VectorXd &epsilon, const double beta_old) override;
 
-    void updateEpsilon(VectorXd &epsilon,
-                       const double beta_old,
-                       const double beta) override;
+    VectorXdPtr calculateEpsilonChange(const double beta_old,
+                                       const double beta) override;
 
     virtual void updateStatistics(unsigned int allele1, unsigned int allele2);
 


### PR DESCRIPTION
Profiling revealed that calls to setZero were taking a significant amount of time. This call essentially sets each value in the data structure to zero, one at a time.

Firstly, refactor the calls to setZero so that it only affected the ragged sparse data type.
Then we use an alternate call: VectorXd::Constant to initialise a vector of a given size to a given value.
Finally we replace other instances of setZero. Note that we do not change other analysis algorithms that use this call (BayesRRm).

These changes reduce the profiling run time on my machine from 06:39.250s to 04:46.970s.