### PR TITLE
 Remove memcpy from BayesRBase::processColumnAsync

### DIFF
--- a/src/densemarker.cpp
+++ b/src/densemarker.cpp
@@ -5,7 +5,7 @@
 
 #include <fstream>
 
-double DenseMarker::computeNum(VectorXd &epsilon, const double beta_old)
+double DenseMarker::computeNum(const VectorXd &epsilon, const double beta_old)
 {
     //in order to not break async and sync updates for dense we change this
     //we now CX dot CX = N-1 given that both are already centered and scaled

--- a/src/densemarker.h
+++ b/src/densemarker.h
@@ -11,7 +11,7 @@ struct DenseMarker : public Marker
     std::shared_ptr<unsigned char[]> buffer = nullptr;
     std::shared_ptr<Map<VectorXd>> Cx = nullptr;
 
-    double computeNum(VectorXd &epsilon, const double beta_old) override;
+    double computeNum(const VectorXd &epsilon, const double beta_old) override;
     VectorXdPtr calculateEpsilonChange(const double beta_old,
                                        const double beta) override;
 

--- a/src/marker.h
+++ b/src/marker.h
@@ -23,7 +23,7 @@ struct Marker
     unsigned int i = 0;
     unsigned int numInds = 0;
 
-    virtual double computeNum(VectorXd &epsilon,
+    virtual double computeNum(const VectorXd &epsilon,
                               const double beta_old) = 0;
 
     virtual VectorXdPtr calculateEpsilonChange(const double beta_old,

--- a/src/sparsemarker.cpp
+++ b/src/sparsemarker.cpp
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <iostream>
 
-double SparseMarker::computeNum(VectorXd &epsilon, const double beta_old)
+double SparseMarker::computeNum(const VectorXd &epsilon, const double beta_old)
 {
     return computeNum(epsilon, beta_old, epsilonSum);
 }
@@ -71,7 +71,7 @@ void SparseMarker::write(std::ostream *outStream) const
     writeDouble(Zsum);
 }
 
-double SparseMarker::computeNum(VectorXd &epsilon, const double beta_old, const double epsilonSum)
+double SparseMarker::computeNum(const VectorXd &epsilon, const double beta_old, const double epsilonSum)
 {
     return beta_old * (static_cast<double>(numInds) - 1.0) - mean * epsilonSum / sd + dot(epsilon);
 }

--- a/src/sparsemarker.h
+++ b/src/sparsemarker.h
@@ -12,7 +12,7 @@ struct SparseMarker : public Marker
 
     double epsilonSum = 0;
 
-    double computeNum(VectorXd &epsilon, const double beta_old) override;
+    double computeNum(const VectorXd &epsilon, const double beta_old) override;
 
     VectorXdPtr calculateEpsilonChange(const double beta_old,
                                        const double beta) override;
@@ -24,7 +24,7 @@ struct SparseMarker : public Marker
     void write(std::ostream *outStream) const override;
 
 protected:
-    virtual double computeNum(VectorXd &epsilon,
+    virtual double computeNum(const VectorXd &epsilon,
                               const double beta_old,
                               const double epsilonSum);
 


### PR DESCRIPTION
A local copy of epsilon is no longer required in the asynchronous algorithm so we remove the memcpy. Instead, we pass a const &VectorXd to Marker::computeNum.

It may be the case that we can remove the locking altogether.

Using the ragged data type and the very large dataset I have here, an asynchronous iteration takes 35s, whilst a synchronous iteration takes 68s.