### PR TITLE
Clean up CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.3)
 
 option(BRR_TRACE_FLOW_GRAPH "Enable flow graph tracing" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,50 @@
 cmake_minimum_required(VERSION 3.1.3)
 
-option(BRR_TRACE_FLOW_GRAPH "Enable flow graph tracing" OFF)
+option(ENABLE_FLOW_GRAPH_TRACING "Enable flow graph tracing" OFF)
+option(ENABLE_UNIT_TESTS "Enable unit tests" OFF)
+option(ENABLE_FAST_OPTIMIZATONS "Enable more compiler optimizations" OFF)
 
-if(BRR_TRACE_FLOW_GRAPH)
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/eigen/Eigen/)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/eigen/)
+
+    # Silence some annoying warnings form Eigen with gcc >= 6.1
+    SET(GCC_EIGEN_COMPILE_FLAGS "-Wno-ignored-attributes -Wno-deprecated-declarations -DEIGEN_NO_DEBUG -DEIGEN_UNROLLING_LIMIT=1000")
+else()
+    message(FATAL_ERROR "Cound not find Eigen submodule!")
+endif()
+
+find_package(Threads REQUIRED)
+
+find_package(Boost REQUIRED)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+endif()
+
+find_package(ZLIB REQUIRED)
+if(ZLIB_FOUND)
+  include_directories(${ZLIB_INCLUDE_DIRS})
+endif(ZLIB_FOUND)
+
+set(TBB_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/tbb)
+include(${TBB_ROOT}/cmake/TBBBuild.cmake)
+tbb_build(TBB_ROOT ${TBB_ROOT} CONFIG_DIR TBB_DIR MAKE_ARGS stdver=c++17 tbb_cpf=1)
+find_package(TBB REQUIRED tbb_preview)
+
+include(CheckCXXCompilerFlag)
+
+# Check for -march=native support in the compiler
+CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
+if(COMPILER_SUPPORTS_MARCH_NATIVE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+endif()
+
+if(ENABLE_FAST_OPTIMIZATONS)
+    SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -ffast-math -funroll-loops ")
+endif()
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_EIGEN_COMPILE_FLAGS}")
+
+if(ENABLE_FLOW_GRAPH_TRACING)
     add_definitions(-DTBB_USE_THREADING_TOOLS)
     add_definitions(-DTBB_PREVIEW_FLOW_GRAPH_TRACE)
     add_definitions(-DTBB_PREVIEW_FLOW_GRAPH_FEATURES)
@@ -11,6 +53,6 @@ endif()
 
 add_subdirectory(src)
 
-if(TEST)
-	add_subdirectory(test)
+if(ENABLE_UNIT_TESTS)
+    add_subdirectory(test)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1.3)
-
 project(brr)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ project(brr)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-add_library(libbrr-dev
+add_library(bayes
     BayesRRm.cpp
     data.cpp
     distributions_boost.cpp
@@ -32,10 +32,10 @@ add_library(libbrr-dev
     colwriter.cpp
 )
 
-set_property(TARGET libbrr-dev PROPERTY CXX_STANDARD_REQUIRED ON)
-set_property(TARGET libbrr-dev PROPERTY CXX_STANDARD 17)
+set_property(TARGET bayes PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET bayes PROPERTY CXX_STANDARD 17)
 
-target_link_libraries(libbrr-dev ${ZLIB_LIBRARIES} ${TBB_IMPORTED_TARGETS}
+target_link_libraries(bayes ${ZLIB_LIBRARIES} ${TBB_IMPORTED_TARGETS}
     ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(${PROJECT_NAME}
@@ -45,7 +45,7 @@ add_executable(${PROJECT_NAME}
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 
-target_link_libraries(${PROJECT_NAME} libbrr-dev)
+target_link_libraries(${PROJECT_NAME} bayes)
 
 set(${PROJECT_NAME}_INCLUDE_DIRS ${PROJECT_SOURCE_DIR} ${PROJECT_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR} CACHE INTERNAL "${PROJECT_NAME}: Include Directories"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,33 +71,6 @@ add_library(libbrr-dev
 
 add_executable(${PROJECT_NAME}
     main.cpp
-    BayesRRm.cpp
-    data.cpp
-    distributions_boost.cpp
-    gadgets.cpp
-    options.cpp
-    samplewriter.cpp
-    compression.cpp
-    limitsequencegraph.cpp
-    parallelgraph.cpp
-    analysisgraph.cpp
-    BayesRBase.cpp
-    DenseBayesRRmz.cpp
-    SparseBayesRRG.cpp
-    marker.cpp
-    densemarker.cpp
-    sparsemarker.cpp
-    raggedsparsemarker.cpp
-    eigensparsemarker.cpp
-    common.cpp
-    markerbuilder.cpp
-    densemarkerbuilder.cpp
-    raggedsparsemarkerbuilder.cpp
-    preprocessgraph.cpp
-    eigensparsemarkerbuilder.cpp
-    writer.cpp
-    logwriter.cpp
-    colwriter.cpp
 )
 
 set_property(TARGET libbrr-dev PROPERTY CXX_STANDARD_REQUIRED ON)
@@ -109,7 +82,6 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 find_package(ZLIB REQUIRED)
 if(ZLIB_FOUND)
   include_directories(${ZLIB_INCLUDE_DIRS})
-  target_link_libraries(${PROJECT_NAME} ${ZLIB_LIBRARIES})
   target_link_libraries(libbrr-dev ${ZLIB_LIBRARIES})
 endif(ZLIB_FOUND)
 
@@ -118,10 +90,10 @@ include(${TBB_ROOT}/cmake/TBBBuild.cmake)
 tbb_build(TBB_ROOT ${TBB_ROOT} CONFIG_DIR TBB_DIR MAKE_ARGS stdver=c++17 tbb_cpf=1)
 find_package(TBB REQUIRED tbb_preview)
 
-target_link_libraries(${PROJECT_NAME} ${TBB_IMPORTED_TARGETS})
 target_link_libraries(libbrr-dev ${TBB_IMPORTED_TARGETS})
-target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(libbrr-dev ${CMAKE_THREAD_LIBS_INIT})
+
+target_link_libraries(${PROJECT_NAME} libbrr-dev)
 
 set(${PROJECT_NAME}_INCLUDE_DIRS ${PROJECT_SOURCE_DIR} ${PROJECT_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIR} CACHE INTERNAL "${PROJECT_NAME}: Include Directories" FORCE)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,43 +2,6 @@ project(brr)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../eigen/Eigen/)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../eigen/)
-else()
-    message(FATAL_ERROR "Cound not find Eigen submodule!")
-endif()
-
-find_package(Boost REQUIRED)
-if(Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-endif()
-
-find_package(Threads)
-
-include(CheckCXXCompilerFlag)
-
-# Check for -march=native support in the compiler
-CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
-if(COMPILER_SUPPORTS_MARCH_NATIVE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
-endif()
-
-# Silence some annoying warnings form Eigen with gcc >= 6.1
-SET(GCC_EIGEN_COMPILE_FLAGS "-Wno-ignored-attributes -Wno-deprecated-declarations -DEIGEN_NO_DEBUG  -DEIGEN_UNROLLING_LIMIT=1000")
-
-if(FAST)
-	SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -ffast-math  -funroll-loops ")
-endif()
-
-
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_EIGEN_COMPILE_FLAGS}")
-
-#conditional compilation if using parallelised or vectorised reductions
-if(PARUP)
-  add_definitions(-DPARUP)
-endif()
-
-
 add_library(libbrr-dev
     BayesRRm.cpp
     data.cpp
@@ -69,32 +32,21 @@ add_library(libbrr-dev
     colwriter.cpp
 )
 
+set_property(TARGET libbrr-dev PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET libbrr-dev PROPERTY CXX_STANDARD 17)
+
+target_link_libraries(libbrr-dev ${ZLIB_LIBRARIES} ${TBB_IMPORTED_TARGETS}
+    ${CMAKE_THREAD_LIBS_INIT})
+
 add_executable(${PROJECT_NAME}
     main.cpp
 )
 
-set_property(TARGET libbrr-dev PROPERTY CXX_STANDARD_REQUIRED ON)
-set_property(TARGET libbrr-dev PROPERTY CXX_STANDARD 17)
-
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 
-find_package(ZLIB REQUIRED)
-if(ZLIB_FOUND)
-  include_directories(${ZLIB_INCLUDE_DIRS})
-  target_link_libraries(libbrr-dev ${ZLIB_LIBRARIES})
-endif(ZLIB_FOUND)
-
-set(TBB_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../tbb)
-include(${TBB_ROOT}/cmake/TBBBuild.cmake)
-tbb_build(TBB_ROOT ${TBB_ROOT} CONFIG_DIR TBB_DIR MAKE_ARGS stdver=c++17 tbb_cpf=1)
-find_package(TBB REQUIRED tbb_preview)
-
-target_link_libraries(libbrr-dev ${TBB_IMPORTED_TARGETS})
-target_link_libraries(libbrr-dev ${CMAKE_THREAD_LIBS_INIT})
-
 target_link_libraries(${PROJECT_NAME} libbrr-dev)
 
-set(${PROJECT_NAME}_INCLUDE_DIRS ${PROJECT_SOURCE_DIR} ${PROJECT_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIR} CACHE INTERNAL "${PROJECT_NAME}: Include Directories" FORCE)
-
-    
+set(${PROJECT_NAME}_INCLUDE_DIRS ${PROJECT_SOURCE_DIR} ${PROJECT_INCLUDE_DIRS}
+    ${EIGEN3_INCLUDE_DIR} CACHE INTERNAL "${PROJECT_NAME}: Include Directories"
+    FORCE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,13 +23,6 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
                  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
                  EXCLUDE_FROM_ALL)
 
-find_package(Boost REQUIRED)
-if(Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-endif()
-
-
-
 # Now simply link against gtest or gtest_main as needed. 
 
 add_executable(tests functionTest.cpp)
@@ -37,20 +30,7 @@ add_executable(tests functionTest.cpp)
 set_property(TARGET tests PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET tests PROPERTY CXX_STANDARD 17)
 
-find_package(ZLIB REQUIRED)
-if(ZLIB_FOUND)
-  include_directories(${ZLIB_INCLUDE_DIRS})
-  target_link_libraries(tests ${ZLIB_LIBRARIES})
-endif(ZLIB_FOUND)
-
-
-set(TBB_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../tbb)
-include(${TBB_ROOT}/cmake/TBBBuild.cmake)
-tbb_build(TBB_ROOT ${TBB_ROOT} CONFIG_DIR TBB_DIR MAKE_ARGS stdver=c++17 tbb_cpf=1)
-find_package(TBB REQUIRED tbb_preview)
-
-
+target_link_libraries(tests ${ZLIB_LIBRARIES})
 target_link_libraries(tests gtest_main libbrr-dev ${TBB_IMPORTED_TARGETS} )
-
 
 add_test(NAME example_test COMMAND tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,6 @@ set_property(TARGET tests PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET tests PROPERTY CXX_STANDARD 17)
 
 target_link_libraries(tests ${ZLIB_LIBRARIES})
-target_link_libraries(tests gtest_main libbrr-dev ${TBB_IMPORTED_TARGETS} )
+target_link_libraries(tests gtest_main bayes ${TBB_IMPORTED_TARGETS} )
 
 add_test(NAME example_test COMMAND tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1.3)
-
 include_directories("${brr_INCLUDE_DIRS}")
 configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
@@ -24,13 +22,6 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
                  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
                  EXCLUDE_FROM_ALL)
-
-# The gtest/gtest_main targets carry header search path
-# dependencies automatically when using CMake 2.8.11 or
-# later. Otherwise we have to add them here ourselves.
-if (CMAKE_VERSION VERSION_LESS 2.8.11)
-  include_directories("${gtest_SOURCE_DIR}/include")
-endif()
 
 find_package(Boost REQUIRED)
 if(Boost_FOUND)


### PR DESCRIPTION
A clean build will be required, and **I strongly recommend testing** this well on the different platforms before merging, and commenting here with any issues.

Move find_package calls into the root CMakeLists.
Make configurable options a bit clearer.
The executable brr now links against libbayes.a, as do the unit tests.

The main aim of this pull request is to build the bayes sources once, not twice.

