### PR TITLE
Add AnalysisRunner::makeAnalysisGraph

### DIFF
--- a/src/analysisrunner.cpp
+++ b/src/analysisrunner.cpp
@@ -196,16 +196,7 @@ bool runBayesAnalysis(const Options &options) {
     if (options.numThreadSpawned > 0)
         taskScheduler = std::make_unique<tbb::task_scheduler_init>(options.numThreadSpawned);
 
-    std::unique_ptr<AnalysisGraph> graph {nullptr};
-    if (options.analysisType == AnalysisType::AsyncPpBayes
-            || options.analysisType == AnalysisType::AsyncGauss) {
-        graph = std::make_unique<ParallelGraph>(options.decompressionTokens, options.analysisTokens);
-        auto *parallelGraph = dynamic_cast<ParallelGraph*>(graph.get());
-        parallelGraph->setDecompressionNodeConcurrency(options.decompressionNodeConcurrency);
-        parallelGraph->setAnalysisNodeConcurrency(options.analysisNodeConcurrency);
-    } else {
-        graph = std::make_unique<LimitSequenceGraph>(options.numThread);
-    }
+    auto graph = AnalysisRunner::makeAnalysisGraph(options);
 
     auto cleanup = [&data]() {
         data.unmapCompressedPreprocessedBedFile();

--- a/src/analysisrunner.h
+++ b/src/analysisrunner.h
@@ -1,9 +1,14 @@
 #ifndef ANALYSISRUNNER_H
 #define ANALYSISRUNNER_H
 
+#include <memory>
+
 struct Options;
 
+class AnalysisGraph;
+
 namespace AnalysisRunner {
+std::unique_ptr<AnalysisGraph> makeAnalysisGraph(const Options &options);
 bool run(const Options &options);
 }
 

--- a/src/limitsequencegraph.cpp
+++ b/src/limitsequencegraph.cpp
@@ -71,6 +71,11 @@ LimitSequenceGraph::LimitSequenceGraph(size_t maxParallel)
     make_edge(*m_samplingNode, m_limit->decrement);
 }
 
+LimitSequenceGraph::~LimitSequenceGraph()
+{
+    m_graph->wait_for_all();
+}
+
 void LimitSequenceGraph::exec(Analysis *analysis,
                               unsigned int numInds,
                               unsigned int numSnps,

--- a/src/limitsequencegraph.hpp
+++ b/src/limitsequencegraph.hpp
@@ -15,6 +15,7 @@ class LimitSequenceGraph : public AnalysisGraph
 {
 public:
     explicit LimitSequenceGraph(size_t maxParallel = 12);
+    ~LimitSequenceGraph();
 
     bool isAsynchronous() const override { return false; }
 

--- a/src/parallelgraph.cpp
+++ b/src/parallelgraph.cpp
@@ -121,6 +121,11 @@ ParallelGraph::ParallelGraph(size_t maxDecompressionTokens, size_t maxAnalysisTo
     make_edge(output_port<1>(*m_globalUpdateNode), *m_analysisControlNode);
 }
 
+ParallelGraph::~ParallelGraph()
+{
+    m_graph->wait_for_all();
+}
+
 void ParallelGraph::exec(Analysis *analysis,
                               unsigned int numInds,
                               unsigned int numSnps,

--- a/src/parallelgraph.h
+++ b/src/parallelgraph.h
@@ -22,6 +22,7 @@ class ParallelGraph : public AnalysisGraph
 {
 public:
     explicit ParallelGraph(size_t decompressionTokens, size_t analysisTokens);
+    ~ParallelGraph();
 
     bool isAsynchronous() const override { return true; }
 

--- a/src/preprocessgraph.cpp
+++ b/src/preprocessgraph.cpp
@@ -144,6 +144,11 @@ PreprocessGraph::PreprocessGraph(size_t maxParallel)
     make_edge(*m_writeNode, m_limit->decrement);
 }
 
+PreprocessGraph::~PreprocessGraph()
+{
+    m_graph->wait_for_all();
+}
+
 void PreprocessGraph::preprocessBedFile(const std::string &dataFile,
                                         const PreprocessDataType type,
                                         const bool compress,

--- a/src/preprocessgraph.h
+++ b/src/preprocessgraph.h
@@ -17,7 +17,8 @@ using namespace tbb::flow;
 class PreprocessGraph
 {
 public:
-    PreprocessGraph(size_t maxParallel);
+    explicit PreprocessGraph(size_t maxParallel);
+    ~PreprocessGraph();
 
     void preprocessBedFile(const std::string &dataFile,
                            const PreprocessDataType type,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(tests
     optionstest.cpp
     ppbayestest.cpp
     bayeswtest.cpp
+    analysisrunnertest.cpp
 )
 
 target_compile_definitions(tests PRIVATE TEST_DATA="${CMAKE_CURRENT_SOURCE_DIR}/../test/data/")

--- a/test/analysisrunnertest.cpp
+++ b/test/analysisrunnertest.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include "analysisrunner.h"
+#include "limitsequencegraph.hpp"
+#include "options.hpp"
+#include "parallelgraph.h"
+
+#include <memory>
+
+TEST(AnalysisRunnerTest, makeAnalysisGraph) {
+
+    Options options;
+
+    {
+        // AnalysisType::Unknown
+        auto graph = AnalysisRunner::makeAnalysisGraph(options);
+        ASSERT_EQ(nullptr, graph);
+    }
+
+    {
+        options.analysisType = AnalysisType::Preprocess;
+        auto graph = AnalysisRunner::makeAnalysisGraph(options);
+        ASSERT_EQ(nullptr, graph);
+    }
+
+    {
+        options.analysisType = AnalysisType::PpBayes;
+        auto graph = AnalysisRunner::makeAnalysisGraph(options);
+        auto limitSequenceGraph = dynamic_cast<LimitSequenceGraph*>(graph.get());
+        ASSERT_TRUE(limitSequenceGraph);
+    }
+
+    {
+        options.analysisType = AnalysisType::AsyncPpBayes;
+        auto graph = AnalysisRunner::makeAnalysisGraph(options);
+        auto parallelGraph = dynamic_cast<ParallelGraph*>(graph.get());
+        ASSERT_TRUE(parallelGraph);
+    }
+
+    {
+        options.analysisType = AnalysisType::Gauss;
+        auto graph = AnalysisRunner::makeAnalysisGraph(options);
+        auto limitSequenceGraph = dynamic_cast<LimitSequenceGraph*>(graph.get());
+        ASSERT_TRUE(limitSequenceGraph);
+    }
+
+    {
+        options.analysisType = AnalysisType::AsyncGauss;
+        auto graph = AnalysisRunner::makeAnalysisGraph(options);
+        auto parallelGraph = dynamic_cast<ParallelGraph*>(graph.get());
+        ASSERT_TRUE(parallelGraph);
+    }
+}


### PR DESCRIPTION
The function returns an AnalysisGraph based on the input options.
Added tests to validate that the correct AnalysisGraphs are returned.
Fixed crash caused by destroying `tbb::graph` objects before calling `tbb::graph::wait_for_all`.
