### PR TITLE
Add basic MarkerCache and Sequerntial analysis

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(bayes
     DenseBayesRRmz.cpp
     densebayesw.cpp
     SparseBayesRRG.cpp
+    sequential.cpp
     sparsebayesrkernel.cpp
     sparsebayesw.cpp
     marker.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(bayes
     sparsebayesrkernel.cpp
     sparsebayesw.cpp
     marker.cpp
+    markercache.cpp
     densemarker.cpp
     sparsemarker.cpp
     raggedbayesrkernel.cpp

--- a/src/DenseBayesRRmz.cpp
+++ b/src/DenseBayesRRmz.cpp
@@ -20,9 +20,9 @@ DenseBayesRRmz::~DenseBayesRRmz()
 {
 }
 
-std::unique_ptr<Kernel> DenseBayesRRmz::kernelForMarker(const Marker *marker) const
+std::unique_ptr<Kernel> DenseBayesRRmz::kernelForMarker(const ConstMarkerPtr &marker) const
 {
-    const auto* denseMarker = dynamic_cast<const DenseMarker*>(marker);
+    const auto denseMarker = dynamic_pointer_cast<const DenseMarker>(marker);
     assert(denseMarker);
     return std::make_unique<DenseRKernel>(denseMarker);
 }

--- a/src/DenseBayesRRmz.hpp
+++ b/src/DenseBayesRRmz.hpp
@@ -19,7 +19,7 @@ public:
     explicit DenseBayesRRmz(const Data *data, const Options *opt);
     ~DenseBayesRRmz() override;
 
-    std::unique_ptr<Kernel> kernelForMarker(const Marker *marker) const override;
+    std::unique_ptr<Kernel> kernelForMarker(const ConstMarkerPtr &marker) const override;
     MarkerBuilder *markerBuilder() const override;
 
     void updateMu(double old_mu,double N) override;

--- a/src/SparseBayesRRG.cpp
+++ b/src/SparseBayesRRG.cpp
@@ -15,19 +15,19 @@ SparseBayesRRG::~SparseBayesRRG()
 
 }
 
-std::unique_ptr<Kernel> SparseBayesRRG::kernelForMarker(const Marker *marker) const
+std::unique_ptr<Kernel> SparseBayesRRG::kernelForMarker(const ConstMarkerPtr &marker) const
 {
     switch (m_opt->preprocessDataType) {
     case PreprocessDataType::SparseEigen:
     {
-        const auto* eigenSparseMarker = dynamic_cast<const EigenSparseMarker*>(marker);
+        const auto eigenSparseMarker = dynamic_pointer_cast<const EigenSparseMarker>(marker);
         assert(eigenSparseMarker);
         return std::make_unique<EigenBayesRKernel>(eigenSparseMarker);
     }
 
     case PreprocessDataType::SparseRagged:
     {
-        const auto* raggedSparseMarker = dynamic_cast<const RaggedSparseMarker*>(marker);
+        const auto raggedSparseMarker = dynamic_pointer_cast<const RaggedSparseMarker>(marker);
         assert(raggedSparseMarker);
         return std::make_unique<RaggedBayesRKernel>(raggedSparseMarker);
     }

--- a/src/SparseBayesRRG.hpp
+++ b/src/SparseBayesRRG.hpp
@@ -13,7 +13,7 @@ public:
     explicit SparseBayesRRG(const Data *data, const Options *opt);
     ~SparseBayesRRG() override;
 
-    std::unique_ptr<Kernel> kernelForMarker(const Marker *marker) const override;
+    std::unique_ptr<Kernel> kernelForMarker(const ConstMarkerPtr &marker) const override;
     MarkerBuilder *markerBuilder() const override;
 
     void updateGlobal(Kernel *kernel, const double beta_old, const double beta, const VectorXd &deltaEps ) override;

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -27,7 +27,7 @@ public:
     explicit Analysis(const Data *data, const Options *opt);
     virtual ~Analysis();
 
-    virtual std::unique_ptr<Kernel> kernelForMarker(const Marker *marker) const = 0;
+    virtual std::unique_ptr<Kernel> kernelForMarker(const ConstMarkerPtr &marker) const = 0;
 
     virtual MarkerBuilder* markerBuilder() const = 0;
     virtual IndexEntry indexEntry(unsigned int i) const;

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -1,6 +1,7 @@
 #ifndef ANALYSIS_H
 #define ANALYSIS_H
 
+#include "common.h"
 #include "data.hpp"
 #include "options.hpp"
 
@@ -11,7 +12,6 @@ using namespace Eigen;
 
 struct Kernel;
 struct IndexEntry;
-struct Marker;
 
 class AnalysisGraph;
 class MarkerBuilder;

--- a/src/analysisrunner.cpp
+++ b/src/analysisrunner.cpp
@@ -241,7 +241,10 @@ std::unique_ptr<AnalysisGraph> makeAnalysisGraph(const Options &options)
         // Fall through
     case AnalysisType::AsyncGauss:
     {
-        auto parallelGraph = std::make_unique<ParallelGraph>(options.decompressionTokens, options.analysisTokens);
+        static const bool useMarkerCache = false;
+        auto parallelGraph = std::make_unique<ParallelGraph>(options.decompressionTokens,
+                                                             options.analysisTokens,
+                                                             useMarkerCache);
         parallelGraph->setDecompressionNodeConcurrency(options.decompressionNodeConcurrency);
         parallelGraph->setAnalysisNodeConcurrency(options.analysisNodeConcurrency);
         return std::move(parallelGraph);

--- a/src/analysisrunner.cpp
+++ b/src/analysisrunner.cpp
@@ -7,10 +7,12 @@
 #include "DenseBayesRRmz.hpp"
 #include "densebayesw.h"
 #include "limitsequencegraph.hpp"
+#include "markercache.h"
 #include "options.hpp"
 #include "parallelgraph.h"
 #include "preprocessgraph.h"
 #include "SparseBayesRRG.hpp"
+#include "sequential.h"
 #include "sparsebayesw.h"
 
 using namespace std;
@@ -196,6 +198,14 @@ bool runBayesAnalysis(const Options &options) {
     if (options.numThreadSpawned > 0)
         taskScheduler = std::make_unique<tbb::task_scheduler_init>(options.numThreadSpawned);
 
+    if (options.useMarkerCache) {
+        clock_t start_cache = clock();
+        markerCache()->populate(&data, &options);
+        clock_t end_cache = clock();
+        printf("Populated cache in %.3f sec.\n", double(end_cache - start_cache) / double(CLOCKS_PER_SEC));
+        cout << endl;
+    }
+
     auto graph = AnalysisRunner::makeAnalysisGraph(options);
 
     auto cleanup = [&data]() {
@@ -235,16 +245,20 @@ std::unique_ptr<AnalysisGraph> makeAnalysisGraph(const Options &options)
     case AnalysisType::PpBayes:
         // Fall through
     case AnalysisType::Gauss:
-        return std::make_unique<LimitSequenceGraph>(options.numThread);
+    {
+        if (options.useMarkerCache)
+            return std::make_unique<::Sequential>(); // Differentiate from Eigen::Sequential
+        else
+            return std::make_unique<LimitSequenceGraph>(options.numThread);
+    }
 
     case AnalysisType::AsyncPpBayes:
         // Fall through
     case AnalysisType::AsyncGauss:
     {
-        static const bool useMarkerCache = false;
         auto parallelGraph = std::make_unique<ParallelGraph>(options.decompressionTokens,
                                                              options.analysisTokens,
-                                                             useMarkerCache);
+                                                             options.useMarkerCache);
         parallelGraph->setDecompressionNodeConcurrency(options.decompressionNodeConcurrency);
         parallelGraph->setAnalysisNodeConcurrency(options.analysisNodeConcurrency);
         return std::move(parallelGraph);

--- a/src/bayesrkernel.h
+++ b/src/bayesrkernel.h
@@ -5,7 +5,7 @@
 
 struct BayesRKernel : public Kernel
 {
-    explicit BayesRKernel(const Marker *marker) : Kernel(marker) {}
+    explicit BayesRKernel(const ConstMarkerPtr &marker) : Kernel(marker) {}
     ~BayesRKernel();
 
     virtual double computeNum(const VectorXd &epsilon,

--- a/src/bayeswbase.h
+++ b/src/bayeswbase.h
@@ -9,6 +9,7 @@
 #define BAYESWBASE_H_
 
 #include "analysis.h"
+#include "common.h"
 #include "distributions_boost.hpp"
 
 #include <Eigen/Eigen>
@@ -16,8 +17,6 @@
 
 struct BayesWKernel;
 struct Kernel;
-struct Marker;
-struct MarkerBuilder;
 
 struct beta_params {
     double alpha = 0;

--- a/src/bayeswkernel.h
+++ b/src/bayeswkernel.h
@@ -9,7 +9,7 @@ using namespace Eigen;
 
 struct BayesWKernel : public Kernel
 {
-    explicit BayesWKernel(const Marker *marker) : Kernel(marker) {}
+    explicit BayesWKernel(const ConstMarkerPtr &marker) : Kernel(marker) {}
     ~BayesWKernel();
 
 

--- a/src/common.h
+++ b/src/common.h
@@ -1,8 +1,9 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#include <string>
 #include <iostream>
+#include <memory>
+#include <string>
 
 enum class AnalysisType : unsigned int {
     Unknown = 0,
@@ -31,6 +32,9 @@ enum class PreprocessDataType : unsigned int {
 };
 
 std::ostream &operator<<(std::ostream &os, const PreprocessDataType &obj);
+
+struct Marker;
+using MarkerPtr = std::shared_ptr<Marker>;
 
 class MarkerBuilder;
 MarkerBuilder* builderForType(const PreprocessDataType type);

--- a/src/common.h
+++ b/src/common.h
@@ -35,6 +35,7 @@ std::ostream &operator<<(std::ostream &os, const PreprocessDataType &obj);
 
 struct Marker;
 using MarkerPtr = std::shared_ptr<Marker>;
+using ConstMarkerPtr = std::shared_ptr<const Marker>;
 
 class MarkerBuilder;
 MarkerBuilder* builderForType(const PreprocessDataType type);

--- a/src/densebayesrkernel.cpp
+++ b/src/densebayesrkernel.cpp
@@ -1,8 +1,8 @@
 #include "densebayesrkernel.h"
 
-DenseRKernel::DenseRKernel(const DenseMarker *marker)
+DenseRKernel::DenseRKernel(const std::shared_ptr<const DenseMarker> &marker)
     : BayesRKernel(marker)
-    , dm(marker)
+    , dm(marker.get())
 {
     assert(dm);
 }

--- a/src/densebayesrkernel.h
+++ b/src/densebayesrkernel.h
@@ -6,7 +6,7 @@
 
 struct DenseRKernel : public BayesRKernel
 {
-    explicit DenseRKernel(const DenseMarker *marker);
+    explicit DenseRKernel(const std::shared_ptr<const DenseMarker> &marker);
 
     double computeNum(const VectorXd &epsilon, const double beta_old) override;
     VectorXdPtr calculateEpsilonChange(const double beta_old, const double beta) override;

--- a/src/densebayesw.cpp
+++ b/src/densebayesw.cpp
@@ -40,9 +40,9 @@ DenseBayesW::DenseBayesW(const Data *data, const Options *opt, const long memPag
 
 }
 
-std::unique_ptr<Kernel> DenseBayesW::kernelForMarker(const Marker *marker) const
+std::unique_ptr<Kernel> DenseBayesW::kernelForMarker(const ConstMarkerPtr &marker) const
 {
-    const auto* denseMarker = dynamic_cast<const DenseMarker*>(marker);
+    const auto denseMarker = dynamic_pointer_cast<const DenseMarker>(marker);
     assert(denseMarker);
     return std::make_unique<DenseBayesWKernel>(denseMarker);
 }

--- a/src/densebayesw.h
+++ b/src/densebayesw.h
@@ -15,7 +15,7 @@ class DenseBayesW : public BayesWBase
 public:
     DenseBayesW(const Data *data, const Options *opt, const long m_memPageSize);
 
-    std::unique_ptr<Kernel> kernelForMarker(const Marker *marker) const override;
+    std::unique_ptr<Kernel> kernelForMarker(const ConstMarkerPtr &marker) const override;
     MarkerBuilder *markerBuilder() const override;
 
 protected:

--- a/src/densebayeswkernel.cpp
+++ b/src/densebayeswkernel.cpp
@@ -1,8 +1,8 @@
 #include "densebayeswkernel.h"
 
-DenseBayesWKernel::DenseBayesWKernel(const DenseMarker *marker)
+DenseBayesWKernel::DenseBayesWKernel(const std::shared_ptr<const DenseMarker> &marker)
     : BayesWKernel(marker)
-    , dm(marker)
+    , dm(marker.get())
 {
     assert(dm);
 }

--- a/src/densebayeswkernel.h
+++ b/src/densebayeswkernel.h
@@ -6,7 +6,7 @@
 
 struct DenseBayesWKernel : public BayesWKernel
 {
-    explicit DenseBayesWKernel(const DenseMarker *marker);
+    explicit DenseBayesWKernel(const std::shared_ptr<const DenseMarker> &marker);
 
     void setVi(const std::shared_ptr<VectorXd> &vi) override;
     void calculateSumFailure(const VectorXd &failure_vector);

--- a/src/eigenbayesrkernel.cpp
+++ b/src/eigenbayesrkernel.cpp
@@ -1,8 +1,8 @@
 #include "eigenbayesrkernel.h"
 
-EigenBayesRKernel::EigenBayesRKernel(const EigenSparseMarker *marker)
+EigenBayesRKernel::EigenBayesRKernel(const std::shared_ptr<const EigenSparseMarker> &marker)
     : SparseBayesRKernel(marker)
-    , esm(marker)
+    , esm(marker.get())
 {
     assert(esm);
 }

--- a/src/eigenbayesrkernel.h
+++ b/src/eigenbayesrkernel.h
@@ -6,7 +6,7 @@
 
 struct EigenBayesRKernel : public SparseBayesRKernel
 {
-    explicit EigenBayesRKernel(const EigenSparseMarker *marker);
+    explicit EigenBayesRKernel(const std::shared_ptr<const EigenSparseMarker> &marker);
 
     const VectorXd *ones = nullptr;
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -1,6 +1,6 @@
 #include "kernel.h"
 
-Kernel::Kernel(const Marker *marker)
+Kernel::Kernel(const ConstMarkerPtr &marker)
     : marker(marker) {}
 
 Kernel::~Kernel() = default;

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -7,10 +7,10 @@
 
 struct Kernel
 {
-    explicit Kernel(const Marker *marker);
+    explicit Kernel(const ConstMarkerPtr &marker);
     virtual ~Kernel();
 
-    std::unique_ptr<const Marker> marker = nullptr;
+    ConstMarkerPtr marker = nullptr;
 };
 
 #endif // KERNEL_H

--- a/src/markerbuilder.cpp
+++ b/src/markerbuilder.cpp
@@ -36,7 +36,7 @@ void MarkerBuilder::decompress(unsigned char *data, const IndexEntry &index) con
     m_marker->decompress(data, index);
 }
 
-Marker *MarkerBuilder::build()
+std::unique_ptr<Marker> MarkerBuilder::build()
 {
     if (!m_marker) {
         std::cerr << "Not building Marker, was MarkerBuilder::initialise called?" << std::endl;
@@ -49,7 +49,7 @@ Marker *MarkerBuilder::build()
     }
 
     reset();
-    return m_marker.release();
+    return std::move(m_marker);
 }
 
 void MarkerBuilder::reset(const double numInds)

--- a/src/markerbuilder.h
+++ b/src/markerbuilder.h
@@ -30,8 +30,7 @@ public:
     virtual Marker* build();
 
 protected:
-    using MarkerPtr = std::unique_ptr<Marker>;
-    MarkerPtr m_marker = nullptr;
+    std::unique_ptr<Marker> m_marker = nullptr;
 
     unsigned int m_snp = 0;
     double m_numInds = 0;

--- a/src/markerbuilder.h
+++ b/src/markerbuilder.h
@@ -27,7 +27,7 @@ public:
     virtual void decompress(unsigned char *data,
                             const IndexEntry &index) const;
 
-    virtual Marker* build();
+    virtual std::unique_ptr<Marker> build();
 
 protected:
     std::unique_ptr<Marker> m_marker = nullptr;

--- a/src/markercache.cpp
+++ b/src/markercache.cpp
@@ -49,6 +49,7 @@ ConstMarkerPtr MarkerCache::marker(unsigned int i) const
     if (i > m_markers.size()) {
         std::cerr << "Requesting marker out of bounds: " << i << ". "
                   << m_markers.size() << " cached markers." << std::endl;
+        assert(false);
         return {};
     }
 

--- a/src/markercache.cpp
+++ b/src/markercache.cpp
@@ -1,0 +1,56 @@
+#include "markercache.h"
+
+#include "data.hpp"
+#include "marker.h"
+#include "markerbuilder.h"
+#include "options.hpp"
+
+const std::shared_ptr<MarkerCache> markerCache()
+{
+    static const auto cache = std::make_shared<MarkerCache>();
+    return cache;
+}
+
+void MarkerCache::clear()
+{
+    m_markers.clear();
+}
+
+void MarkerCache::populate(const Data *data, const Options *options)
+{
+    assert(data);
+    assert(options);
+
+    if (!data || !options)
+        return;
+
+    clear();
+    m_markers.resize(data->numSnps);
+
+    std::unique_ptr<MarkerBuilder> builder{builderForType(options->preprocessDataType)};
+
+    unsigned int snp = 0;
+    std::for_each(m_markers.begin(), m_markers.end(), [&snp, &builder, &data, &options](ConstMarkerPtr &marker) {
+        builder->initialise(snp, data->numInds);
+        const auto index = data->ppbedIndex[snp];
+        if (options->compress) {
+            builder->decompress(reinterpret_cast<unsigned char*>(data->ppBedMap), index);
+        } else {
+            builder->read(ppFileForType(options->preprocessDataType, options->dataFile), index);
+        }
+        marker = builder->build();
+        ++snp;
+    });
+    std::cout << "Cached " << snp << " markers" << std::endl;
+}
+
+ConstMarkerPtr MarkerCache::marker(unsigned int i) const
+{
+    if (i > m_markers.size()) {
+        std::cerr << "Requesting marker out of bounds: " << i << ". "
+                  << m_markers.size() << " cached markers." << std::endl;
+        return {};
+    }
+
+    return m_markers.at(i);
+}

--- a/src/markercache.h
+++ b/src/markercache.h
@@ -1,0 +1,25 @@
+#ifndef MARKERCACHE_H
+#define MARKERCACHE_H
+
+#include "common.h"
+
+#include <memory>
+#include <vector>
+
+class Data;
+class Options;
+
+class MarkerCache {
+public:
+    void clear();
+    void populate(const Data *data, const Options *options);
+    ConstMarkerPtr marker(unsigned int i) const;
+
+protected:
+    using MarkerPtrList = std::vector<ConstMarkerPtr>;
+    MarkerPtrList m_markers;
+};
+
+const std::shared_ptr<MarkerCache> markerCache();
+
+#endif // MARKERCACHE_H

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -232,6 +232,10 @@ void Options::inputOptions(const int argc, const char* argv[]){
 	     colLogFile = argv[++i];
 	     ss << "--colLog " << argv[i] << "\n";
 	}
+        else if(!strcmp(argv[i], "--marker-cache")) {
+            useMarkerCache = true;
+            ss << "--marker-cache\n";
+        }
         else {
             stringstream errmsg;
             errmsg << "\nError: invalid option \"" << argv[i] << "\".\n";

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -56,6 +56,7 @@ public:
     bool iterLog = false;
     string colLogFile;
     bool colLog =false;
+    bool useMarkerCache = false;
 
     Options(){
         chainLength             = 10000;

--- a/src/parallelgraph.h
+++ b/src/parallelgraph.h
@@ -21,7 +21,7 @@ using namespace tbb::flow;
 class ParallelGraph : public AnalysisGraph
 {
 public:
-    explicit ParallelGraph(size_t decompressionTokens, size_t analysisTokens);
+    explicit ParallelGraph(size_t decompressionTokens, size_t analysisTokens, bool useMarkerCache);
     ~ParallelGraph();
 
     bool isAsynchronous() const override { return true; }
@@ -66,6 +66,9 @@ private:
 
     using decompression_node = function_node<DecompressionTuple, DecompressionTuple>;
     std::unique_ptr<decompression_node> m_decompressionNode;
+
+    using cache_reader_node = function_node<DecompressionTuple, DecompressionTuple, lightweight>;
+    std::unique_ptr<cache_reader_node> m_cacheReaderNode;
 
     using analysis_join_node = join_node<AnalysisTuple, queueing>;
     std::unique_ptr<analysis_join_node> m_analysisJoinNode;

--- a/src/preprocessgraph.cpp
+++ b/src/preprocessgraph.cpp
@@ -57,7 +57,7 @@ PreprocessGraph::PreprocessGraph(size_t maxParallel)
             }
 
             builder->endColumn();
-            msg.snpData.at(chunk).reset(builder->build());
+            msg.snpData.at(chunk) = builder->build();
 
             // Compress the data
             if (msg.compress) {

--- a/src/preprocessgraph.h
+++ b/src/preprocessgraph.h
@@ -38,7 +38,6 @@ protected:
 
         const Data* data = nullptr;
 
-        using MarkerPtr = std::shared_ptr<Marker>;
         using MarkerPtrList = std::vector<MarkerPtr>;
         MarkerPtrList snpData;
 

--- a/src/raggedbayesrkernel.cpp
+++ b/src/raggedbayesrkernel.cpp
@@ -1,8 +1,8 @@
 #include "raggedbayesrkernel.h"
 
-RaggedBayesRKernel::RaggedBayesRKernel(const RaggedSparseMarker *marker)
+RaggedBayesRKernel::RaggedBayesRKernel(const std::shared_ptr<const RaggedSparseMarker> &marker)
     : SparseBayesRKernel (marker)
-    , rsm(marker)
+    , rsm(marker.get())
 {
     assert(rsm);
 }

--- a/src/raggedbayesrkernel.h
+++ b/src/raggedbayesrkernel.h
@@ -6,7 +6,7 @@
 
 struct RaggedBayesRKernel : public SparseBayesRKernel
 {
-    explicit RaggedBayesRKernel(const RaggedSparseMarker *marker);
+    explicit RaggedBayesRKernel(const std::shared_ptr<const RaggedSparseMarker> &marker);
 
     VectorXdPtr calculateEpsilonChange(const double beta_old,
                                        const double beta) override;

--- a/src/raggedbayeswkernel.cpp
+++ b/src/raggedbayeswkernel.cpp
@@ -1,8 +1,8 @@
 #include "raggedbayeswkernel.h"
 
-RaggedBayesWKernel::RaggedBayesWKernel(const RaggedSparseMarker *marker)
+RaggedBayesWKernel::RaggedBayesWKernel(const std::shared_ptr<const RaggedSparseMarker> &marker)
     : BayesWKernel (marker)
-    , rsm(marker)
+    , rsm(marker.get())
 {
     assert(marker);
 }

--- a/src/raggedbayeswkernel.h
+++ b/src/raggedbayeswkernel.h
@@ -6,7 +6,7 @@
 
 struct RaggedBayesWKernel : public BayesWKernel
 {
-    explicit RaggedBayesWKernel(const RaggedSparseMarker *marker);
+    explicit RaggedBayesWKernel(const std::shared_ptr<const RaggedSparseMarker> &marker);
 
     double vi_sum = 0;
     double vi_2 = 0;

--- a/src/sequential.cpp
+++ b/src/sequential.cpp
@@ -1,0 +1,27 @@
+#include "sequential.h"
+
+#include "analysis.h"
+#include "kernel.h"
+#include "markercache.h"
+
+#include <algorithm>
+#include <iostream>
+
+void Sequential::exec(Analysis *analysis,
+                      unsigned int numInds,
+                      unsigned int numSnps,
+                      const std::vector<unsigned int> &markerIndices)
+{
+    (void) numInds; // Unused
+    (void) numSnps; // Unused
+
+    if (!analysis) {
+        std::cerr << "Cannot run Sequential without bayes" << std::endl;
+        return;
+    }
+
+    std::for_each(markerIndices.cbegin(), markerIndices.cend(), [&analysis](unsigned int i) {
+        auto kernel = analysis->kernelForMarker(markerCache()->marker(i));
+        analysis->processColumn(kernel.get());
+    });
+}

--- a/src/sequential.h
+++ b/src/sequential.h
@@ -1,0 +1,16 @@
+#ifndef SEQUENTIAL_H
+#define SEQUENTIAL_H
+
+#include "analysisgraph.hpp"
+
+class Sequential : public AnalysisGraph
+{
+public:
+    bool isAsynchronous() const override { return false; }
+    void exec(Analysis *analysis,
+              unsigned int numInds,
+              unsigned int numSnps,
+              const std::vector<unsigned int> &markerIndices) override;
+};
+
+#endif

--- a/src/sparsebayesrkernel.cpp
+++ b/src/sparsebayesrkernel.cpp
@@ -1,8 +1,8 @@
 #include "sparsebayesrkernel.h"
 
-SparseBayesRKernel::SparseBayesRKernel(const SparseMarker *marker)
+SparseBayesRKernel::SparseBayesRKernel(const std::shared_ptr<const SparseMarker> &marker)
     : BayesRKernel(marker)
-    , sm(marker)
+    , sm(marker.get())
 {
     assert(sm);
 }

--- a/src/sparsebayesrkernel.h
+++ b/src/sparsebayesrkernel.h
@@ -6,7 +6,7 @@
 
 struct SparseBayesRKernel : public BayesRKernel
 {
-    explicit SparseBayesRKernel(const SparseMarker *marker);
+    explicit SparseBayesRKernel(const std::shared_ptr<const SparseMarker> &marker);
 
     double epsilonSum = 0;
 

--- a/src/sparsebayesw.cpp
+++ b/src/sparsebayesw.cpp
@@ -44,12 +44,12 @@ SparseBayesW::SparseBayesW(const Data *data, const Options *opt, const long memP
 
 }
 
-std::unique_ptr<Kernel> SparseBayesW::kernelForMarker(const Marker *marker) const
+std::unique_ptr<Kernel> SparseBayesW::kernelForMarker(const ConstMarkerPtr &marker) const
 {
     switch (m_opt->preprocessDataType) {
     case PreprocessDataType::SparseRagged:
     {
-        const auto* raggedSparseMarker = dynamic_cast<const RaggedSparseMarker*>(marker);
+        const auto raggedSparseMarker = dynamic_pointer_cast<const RaggedSparseMarker>(marker);
         assert(raggedSparseMarker);
         return std::make_unique<RaggedBayesWKernel>(raggedSparseMarker);
     }

--- a/src/sparsebayesw.h
+++ b/src/sparsebayesw.h
@@ -15,7 +15,7 @@ class SparseBayesW : public BayesWBase
 public:
     SparseBayesW(const Data *data, const Options *opt, const long m_memPageSize);
 
-    std::unique_ptr<Kernel> kernelForMarker(const Marker *marker) const override;
+    std::unique_ptr<Kernel> kernelForMarker(const ConstMarkerPtr &marker) const override;
     MarkerBuilder *markerBuilder() const override;
 
 protected:

--- a/test/bayeswtest.cpp
+++ b/test/bayeswtest.cpp
@@ -46,7 +46,7 @@ protected:
 
 class BayesWTest :
         public BayesWBaseTest,
-        public ::testing::WithParamInterface<std::tuple<AnalysisType, PreprocessDataType, bool>> {
+        public ::testing::WithParamInterface<std::tuple<AnalysisType, PreprocessDataType, bool, bool>> {
 protected:
     void SetUp() {
         BayesWBaseTest::SetUp();
@@ -67,6 +67,7 @@ TEST_P(BayesWTest, SmokeTests) {
     const auto params = GetParam();
     options.preprocessDataType = std::get<1>(params);
     options.compress = std::get<2>(params);
+    options.useMarkerCache = std::get<3>(params);
 
     // Preprocess
     ASSERT_TRUE(AnalysisRunner::run(options));
@@ -86,4 +87,5 @@ INSTANTIATE_TEST_SUITE_P(AnalysisSmokeTests,
                                                   AnalysisType::AsyncGauss}),
                              ::testing::ValuesIn({PreprocessDataType::Dense,
                                                   PreprocessDataType::SparseRagged}),
-                             ::testing::Bool()));
+                             ::testing::Bool(), // compress
+                             ::testing::Bool())); // useMarkerCache

--- a/test/ppbayestest.cpp
+++ b/test/ppbayestest.cpp
@@ -151,7 +151,7 @@ protected:
 
 class PpBayesBed :
         public PpBayesBase,
-        public ::testing::WithParamInterface<std::tuple<AnalysisType, PreprocessDataType, bool>> {
+        public ::testing::WithParamInterface<std::tuple<AnalysisType, PreprocessDataType, bool, bool>> {
 protected:
     void SetUp() {
         PpBayesBase::SetUp();
@@ -168,6 +168,7 @@ TEST_P(PpBayesBed, SmokeTests) {
     const auto params = GetParam();
     options.preprocessDataType = std::get<1>(params);
     options.compress = std::get<2>(params);
+    options.useMarkerCache = std::get<3>(params);
 
     // Preprocess
     ASSERT_TRUE(AnalysisRunner::run(options));
@@ -188,11 +189,12 @@ INSTANTIATE_TEST_SUITE_P(AnalysisSmokeTests,
                              ::testing::ValuesIn({PreprocessDataType::Dense,
                                                   PreprocessDataType::SparseEigen,
                                                   PreprocessDataType::SparseRagged}),
-                             ::testing::Bool()));
+                             ::testing::Bool(), // compress
+                             ::testing::Bool())); // useMarkerCache
 
 class PpBayesBedGroups :
         public PpBayesBase,
-        public ::testing::WithParamInterface<std::tuple<AnalysisType, PreprocessDataType, bool>> {
+        public ::testing::WithParamInterface<std::tuple<AnalysisType, PreprocessDataType, bool, bool>> {
 protected:
     void SetUp() {
         PpBayesBase::SetUp();
@@ -211,6 +213,7 @@ TEST_P(PpBayesBedGroups, SmokeTests) {
     const auto params = GetParam();
     options.preprocessDataType = std::get<1>(params);
     options.compress = std::get<2>(params);
+    options.useMarkerCache = std::get<3>(params);
 
     // Preprocess
     ASSERT_TRUE(AnalysisRunner::run(options));
@@ -231,7 +234,8 @@ INSTANTIATE_TEST_SUITE_P(PpBayesBedGroups,
                              ::testing::ValuesIn({PreprocessDataType::Dense,
                                                   PreprocessDataType::SparseEigen,
                                                   PreprocessDataType::SparseRagged}),
-                             ::testing::Bool()));
+                             ::testing::Bool(), // compress
+                             ::testing::Bool())); // useMarkerCache
 
 
 class PpBayesCsv :


### PR DESCRIPTION
This MarkerCache loads all the Markers on disk and caches them into RAM.
It provides a very simple API which is not suited to populating the
cache in parallel.

This provides us with a basic cache to test performance implication of
caching Markers on the ParallelGraph.

The API is likely to change to support concurrent cache population in
the future.

Sequential does not use TBB, it simply loads the markers from the marker
cache and calls Analysis::processColumn with them. There is no
concurrency involved. Sequential is automatically used with the non-async analysis types when --marker-cache is used.