### PR TITLE
Fix concurrency issues

### DIFF
--- a/src/BayesRBase.cpp
+++ b/src/BayesRBase.cpp
@@ -468,7 +468,7 @@ std::unique_ptr<AsyncResult> BayesRBase::processColumnAsync(Kernel *kernel)
     return result;
 }
 
-void BayesRBase::updateGlobal(const std::shared_ptr<Kernel>& kernel,
+void BayesRBase::updateGlobal(const KernelPtr& kernel,
                               const std::shared_ptr<const AsyncResult>& result)
 {
     assert(kernel);

--- a/src/BayesRBase.cpp
+++ b/src/BayesRBase.cpp
@@ -468,14 +468,13 @@ std::unique_ptr<AsyncResult> BayesRBase::processColumnAsync(Kernel *kernel)
     return result;
 }
 
-void BayesRBase::updateGlobal(Kernel *kernel, const double beta_old, const double beta, const VectorXd &deltaEps)
+void BayesRBase::updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult>& result)
 {
-    (void) beta_old; // Unused;
     assert(kernel);
 
     std::unique_lock lock(m_mutex);
-    m_epsilon += deltaEps;
-    m_betasqnG[m_data->G[kernel->marker->i]] += pow(beta, 2);
+    m_epsilon += *result->deltaEpsilon;
+    m_betasqnG[m_data->G[kernel->marker->i]] += pow(result->beta, 2);
 }
 
 void BayesRBase::printDebugInfo() const

--- a/src/BayesRBase.cpp
+++ b/src/BayesRBase.cpp
@@ -245,9 +245,9 @@ int BayesRBase::runGibbs(AnalysisGraph *analysis)
     return 0;
 }
 
-void BayesRBase::processColumn(Kernel *kernel)
+void BayesRBase::processColumn(const KernelPtr &kernel)
 {
-    auto * bayesKernel = dynamic_cast<BayesRKernel*>(kernel);
+    auto * bayesKernel = dynamic_cast<BayesRKernel*>(kernel.get());
     assert(bayesKernel);
 
     const unsigned int N(m_data->numInds);
@@ -350,9 +350,9 @@ void BayesRBase::processColumn(Kernel *kernel)
 
 }
 
-std::unique_ptr<AsyncResult> BayesRBase::processColumnAsync(Kernel *kernel)
+std::unique_ptr<AsyncResult> BayesRBase::processColumnAsync(const KernelPtr &kernel)
 {
-    auto * bayesKernel = dynamic_cast<BayesRKernel*>(kernel);
+    auto * bayesKernel = dynamic_cast<BayesRKernel*>(kernel.get());
     assert(bayesKernel);
 
     const auto group = m_data->G[bayesKernel->marker->i];

--- a/src/BayesRBase.cpp
+++ b/src/BayesRBase.cpp
@@ -469,7 +469,7 @@ std::unique_ptr<AsyncResult> BayesRBase::processColumnAsync(const KernelPtr &ker
 }
 
 void BayesRBase::updateGlobal(const KernelPtr& kernel,
-                              const std::shared_ptr<const AsyncResult>& result)
+                              const ConstAsyncResultPtr& result)
 {
     assert(kernel);
     assert(result);

--- a/src/BayesRBase.cpp
+++ b/src/BayesRBase.cpp
@@ -468,9 +468,11 @@ std::unique_ptr<AsyncResult> BayesRBase::processColumnAsync(Kernel *kernel)
     return result;
 }
 
-void BayesRBase::updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult>& result)
+void BayesRBase::updateGlobal(const std::shared_ptr<Kernel>& kernel,
+                              const std::shared_ptr<const AsyncResult>& result)
 {
     assert(kernel);
+    assert(result);
 
     std::unique_lock lock(m_mutex);
     m_epsilon += *result->deltaEpsilon;

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -29,8 +29,8 @@ public:
 
     int runGibbs(AnalysisGraph* analysis) override; // where we run Gibbs sampling over the parametrised model
 
-    void processColumn(Kernel *kernel) override;
-    std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) override;
+    void processColumn(const KernelPtr &kernel) override;
+    std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) override;
     void updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result) override;
 
     virtual void updateMu(double old_mu, double N)=0;

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -31,7 +31,7 @@ public:
 
     void processColumn(Kernel *kernel) override;
     std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) override;
-    void updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateGlobal(const std::shared_ptr<Kernel> &kernel, const std::shared_ptr<const AsyncResult> &result) override;
 
     virtual void updateMu(double old_mu, double N)=0;
 

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -31,7 +31,7 @@ public:
 
     void processColumn(const KernelPtr &kernel) override;
     std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) override;
-    void updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateGlobal(const KernelPtr& kernel, const ConstAsyncResultPtr &result) override;
 
     virtual void updateMu(double old_mu, double N)=0;
 

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -82,10 +82,14 @@ protected:
     VectorXd m_y;
     VectorXd m_components;
 
+    static const std::size_t PIndex = 0;
+    static const std::size_t RandomNormIndex = 1;
+    constexpr static const std::size_t RandomNumberColumns = 2; // p, randomNorm
+    std::vector<std::array<double, RandomNumberColumns>> m_randomNumbers;
+
     bool m_isAsync = false;
 
     mutable std::shared_mutex m_mutex;
-    mutable std::mutex m_rngMutex;
 
     void setAsynchronous(bool async) { m_isAsync = async; }
 

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -31,7 +31,7 @@ public:
 
     void processColumn(Kernel *kernel) override;
     std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) override;
-    void updateGlobal(const std::shared_ptr<Kernel> &kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result) override;
 
     virtual void updateMu(double old_mu, double N)=0;
 

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -31,7 +31,7 @@ public:
 
     void processColumn(Kernel *kernel) override;
     std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) override;
-    void updateGlobal(Kernel *kernel, const double beta_old, const double beta, const VectorXd& deltaEps) override;
+    void updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult> &result) override;
 
     virtual void updateMu(double old_mu, double N)=0;
 

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -30,7 +30,9 @@ public:
     int runGibbs(AnalysisGraph* analysis) override; // where we run Gibbs sampling over the parametrised model
 
     void processColumn(const KernelPtr &kernel) override;
+
     std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) override;
+    void doThreadSafeUpdates(const ConstAsyncResultPtr& result) override;
     void updateGlobal(const KernelPtr& kernel, const ConstAsyncResultPtr &result) override;
 
     virtual void updateMu(double old_mu, double N)=0;

--- a/src/BayesRBase.hpp
+++ b/src/BayesRBase.hpp
@@ -84,8 +84,6 @@ protected:
 
     bool m_isAsync = false;
 
-    VectorXd m_asyncEpsilon;
-
     mutable std::shared_mutex m_mutex;
     mutable std::mutex m_rngMutex;
 

--- a/src/DenseBayesRRmz.cpp
+++ b/src/DenseBayesRRmz.cpp
@@ -32,20 +32,6 @@ MarkerBuilder *DenseBayesRRmz::markerBuilder() const
     return builderForType(PreprocessDataType::Dense);
 }
 
-void DenseBayesRRmz::init(int K, unsigned int markerCount, unsigned int individualCount)
-{
-    BayesRBase::init(K, markerCount, individualCount);
-
-    if (m_isAsync)
-        m_asyncEpsilon = VectorXd(individualCount);
-}
-
-void DenseBayesRRmz::prepareForAnylsis()
-{
-    if (m_isAsync)
-        std::memcpy(m_asyncEpsilon.data(), m_epsilon.data(), static_cast<size_t>(m_epsilon.size()) * sizeof(double));
-}
-
 //update for mu, in dense case the cache variable m_epsilonSum is not used
 void DenseBayesRRmz::updateMu(double old_mu,double N)
 {

--- a/src/DenseBayesRRmz.hpp
+++ b/src/DenseBayesRRmz.hpp
@@ -23,11 +23,6 @@ public:
     MarkerBuilder *markerBuilder() const override;
 
     void updateMu(double old_mu,double N) override;
-
-protected:
-    void init(int K, unsigned int markerCount, unsigned int individualCount) override;
-    void prepareForAnylsis() override;
-    
 };
 
 #endif /* SRC_DENSEBAYESRRMZ_H_ */

--- a/src/SparseBayesRRG.cpp
+++ b/src/SparseBayesRRG.cpp
@@ -91,11 +91,11 @@ void SparseBayesRRG::writeWithUniqueLock(BayesRKernel *kernel)
         m_epsilonSum += sparseKernel->epsilonSum;
 }
 
-void SparseBayesRRG::updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult> &result)
+void SparseBayesRRG::updateGlobal(const std::shared_ptr<Kernel> &kernel, const std::shared_ptr<const AsyncResult> &result)
 {
     BayesRBase::updateGlobal(kernel, result);
 
-    auto* sparseKernel = dynamic_cast<SparseBayesRKernel*>(kernel);
+    auto* sparseKernel = dynamic_cast<SparseBayesRKernel*>(kernel.get());
     assert(sparseKernel);
 
     std::unique_lock lock(m_mutex);

--- a/src/SparseBayesRRG.cpp
+++ b/src/SparseBayesRRG.cpp
@@ -91,9 +91,9 @@ void SparseBayesRRG::writeWithUniqueLock(BayesRKernel *kernel)
         m_epsilonSum += sparseKernel->epsilonSum;
 }
 
-void SparseBayesRRG::updateGlobal(Kernel *kernel, const double beta_old, const double beta, const VectorXd& deltaEps)
+void SparseBayesRRG::updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult> &result)
 {
-    BayesRBase::updateGlobal(kernel, beta_old, beta, deltaEps);
+    BayesRBase::updateGlobal(kernel, result);
 
     auto* sparseKernel = dynamic_cast<SparseBayesRKernel*>(kernel);
     assert(sparseKernel);

--- a/src/SparseBayesRRG.cpp
+++ b/src/SparseBayesRRG.cpp
@@ -91,7 +91,7 @@ void SparseBayesRRG::writeWithUniqueLock(BayesRKernel *kernel)
         m_epsilonSum += sparseKernel->epsilonSum;
 }
 
-void SparseBayesRRG::updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result)
+void SparseBayesRRG::updateGlobal(const KernelPtr& kernel, const ConstAsyncResultPtr &result)
 {
     BayesRBase::updateGlobal(kernel, result);
 

--- a/src/SparseBayesRRG.cpp
+++ b/src/SparseBayesRRG.cpp
@@ -97,6 +97,8 @@ void SparseBayesRRG::updateGlobal(Kernel *kernel, const double beta_old, const d
 
     auto* sparseKernel = dynamic_cast<SparseBayesRKernel*>(kernel);
     assert(sparseKernel);
+
+    std::unique_lock lock(m_mutex);
     m_epsilonSum += sparseKernel->epsilonSum; // now epsilonSum contains only deltaEpsilonSum
 }
 

--- a/src/SparseBayesRRG.cpp
+++ b/src/SparseBayesRRG.cpp
@@ -62,19 +62,7 @@ void SparseBayesRRG::init(int K, unsigned int markerCount, unsigned int individu
 {
     BayesRBase::init(K, markerCount, individualCount);
 
-    m_asyncEpsilon = VectorXd(individualCount);
-
-    m_asyncEpsilonSum = m_epsilonSum;
-
     m_ones.setOnes(individualCount);
-}
-
-void SparseBayesRRG::prepareForAnylsis()
-{
-    if (m_isAsync) {
-        std::memcpy(m_asyncEpsilon.data(), m_epsilon.data(), static_cast<size_t>(m_epsilon.size()) * sizeof(double));
-        m_asyncEpsilonSum = m_epsilonSum;
-    }
 }
 
 void SparseBayesRRG::prepare(BayesRKernel *kernel)

--- a/src/SparseBayesRRG.cpp
+++ b/src/SparseBayesRRG.cpp
@@ -91,7 +91,7 @@ void SparseBayesRRG::writeWithUniqueLock(BayesRKernel *kernel)
         m_epsilonSum += sparseKernel->epsilonSum;
 }
 
-void SparseBayesRRG::updateGlobal(const std::shared_ptr<Kernel> &kernel, const std::shared_ptr<const AsyncResult> &result)
+void SparseBayesRRG::updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result)
 {
     BayesRBase::updateGlobal(kernel, result);
 

--- a/src/SparseBayesRRG.hpp
+++ b/src/SparseBayesRRG.hpp
@@ -19,12 +19,9 @@ public:
     void updateGlobal(Kernel *kernel, const double beta_old, const double beta, const VectorXd &deltaEps ) override;
    void updateMu(double old_mu,double N);
 protected:
-    double m_asyncEpsilonSum = 0.0;
-
     VectorXd m_ones;
 
     void init(int K, unsigned int markerCount, unsigned int individualCount) override;
-    void prepareForAnylsis() override;
 
     void prepare(BayesRKernel *kernel) override;
     void readWithSharedLock(BayesRKernel *kernel) override;

--- a/src/SparseBayesRRG.hpp
+++ b/src/SparseBayesRRG.hpp
@@ -16,7 +16,7 @@ public:
     std::unique_ptr<Kernel> kernelForMarker(const ConstMarkerPtr &marker) const override;
     MarkerBuilder *markerBuilder() const override;
 
-    void updateGlobal(const std::shared_ptr<Kernel>& kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result) override;
     void updateMu(double old_mu,double N);
 protected:
     VectorXd m_ones;

--- a/src/SparseBayesRRG.hpp
+++ b/src/SparseBayesRRG.hpp
@@ -16,7 +16,7 @@ public:
     std::unique_ptr<Kernel> kernelForMarker(const ConstMarkerPtr &marker) const override;
     MarkerBuilder *markerBuilder() const override;
 
-    void updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateGlobal(const KernelPtr& kernel, const ConstAsyncResultPtr &result) override;
     void updateMu(double old_mu,double N);
 protected:
     VectorXd m_ones;

--- a/src/SparseBayesRRG.hpp
+++ b/src/SparseBayesRRG.hpp
@@ -16,8 +16,8 @@ public:
     std::unique_ptr<Kernel> kernelForMarker(const ConstMarkerPtr &marker) const override;
     MarkerBuilder *markerBuilder() const override;
 
-    void updateGlobal(Kernel *kernel, const double beta_old, const double beta, const VectorXd &deltaEps ) override;
-   void updateMu(double old_mu,double N);
+    void updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateMu(double old_mu,double N);
 protected:
     VectorXd m_ones;
 

--- a/src/SparseBayesRRG.hpp
+++ b/src/SparseBayesRRG.hpp
@@ -16,7 +16,7 @@ public:
     std::unique_ptr<Kernel> kernelForMarker(const ConstMarkerPtr &marker) const override;
     MarkerBuilder *markerBuilder() const override;
 
-    void updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateGlobal(const std::shared_ptr<Kernel>& kernel, const std::shared_ptr<const AsyncResult> &result) override;
     void updateMu(double old_mu,double N);
 protected:
     VectorXd m_ones;

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -40,7 +40,8 @@ public:
     virtual void processColumn(Kernel *kernel) = 0;
     virtual std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) = 0;
 
-    virtual void updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult>& result) = 0;
+    virtual void updateGlobal(const std::shared_ptr<Kernel>& kernel,
+                              const std::shared_ptr<const AsyncResult>& result) = 0;
 
 protected:
     const Data *m_data = nullptr; // data matrices

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -10,7 +10,6 @@
 
 using namespace Eigen;
 
-struct Kernel;
 struct IndexEntry;
 
 class AnalysisGraph;
@@ -40,7 +39,7 @@ public:
     virtual void processColumn(Kernel *kernel) = 0;
     virtual std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) = 0;
 
-    virtual void updateGlobal(const std::shared_ptr<Kernel>& kernel,
+    virtual void updateGlobal(const KernelPtr& kernel,
                               const std::shared_ptr<const AsyncResult>& result) = 0;
 
 protected:

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -36,8 +36,8 @@ public:
 
     virtual int runGibbs(AnalysisGraph* analysis) = 0;
 
-    virtual void processColumn(Kernel *kernel) = 0;
-    virtual std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) = 0;
+    virtual void processColumn(const KernelPtr &kernel) = 0;
+    virtual std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) = 0;
 
     virtual void updateGlobal(const KernelPtr& kernel,
                               const std::shared_ptr<const AsyncResult>& result) = 0;

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -40,7 +40,7 @@ public:
     virtual std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) = 0;
 
     virtual void updateGlobal(const KernelPtr& kernel,
-                              const std::shared_ptr<const AsyncResult>& result) = 0;
+                              const ConstAsyncResultPtr& result) = 0;
 
 protected:
     const Data *m_data = nullptr; // data matrices

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -40,7 +40,7 @@ public:
     virtual void processColumn(Kernel *kernel) = 0;
     virtual std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) = 0;
 
-    virtual void updateGlobal(Kernel *kernel, const double beta_old, const double beta, const VectorXd& deltaEps) = 0;
+    virtual void updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult>& result) = 0;
 
 protected:
     const Data *m_data = nullptr; // data matrices

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -19,6 +19,7 @@ struct AsyncResult {
     double betaOld = 0.0;
     double beta = 0.0;
     std::unique_ptr<VectorXd> deltaEpsilon;
+    std::unique_ptr<VectorXd> v;
 };
 
 class Analysis {
@@ -36,9 +37,12 @@ public:
 
     virtual int runGibbs(AnalysisGraph* analysis) = 0;
 
+    // LimitSeqeunceGraph
     virtual void processColumn(const KernelPtr &kernel) = 0;
-    virtual std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) = 0;
 
+    // ParallelGraph
+    virtual std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) = 0;
+    virtual void doThreadSafeUpdates(const ConstAsyncResultPtr& result) = 0;
     virtual void updateGlobal(const KernelPtr& kernel,
                               const ConstAsyncResultPtr& result) = 0;
 

--- a/src/bayeswbase.cpp
+++ b/src/bayeswbase.cpp
@@ -950,14 +950,11 @@ std::unique_ptr<AsyncResult> BayesWBase::processColumnAsync(Kernel *kernel)
     return result;
 }
 
-void BayesWBase::updateGlobal(Kernel *kernel, const double beta_old, const double beta, const VectorXd &deltaEps)
+void BayesWBase::updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult>& result)
 {
     (void) kernel; // Unused
-    (void) beta_old; // Unushed
-    (void) beta; // Unused
-
     std::unique_lock lock(m_mutex);
 
-    *m_epsilon += deltaEps;
+    *m_epsilon += *result->deltaEpsilon;
     *m_vi = (m_alpha*m_epsilon->array()-EuMasc).exp();
 }

--- a/src/bayeswbase.cpp
+++ b/src/bayeswbase.cpp
@@ -950,9 +950,13 @@ std::unique_ptr<AsyncResult> BayesWBase::processColumnAsync(Kernel *kernel)
     return result;
 }
 
-void BayesWBase::updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult>& result)
+void BayesWBase::updateGlobal(const std::shared_ptr<Kernel>& kernel,
+                              const std::shared_ptr<const AsyncResult>& result)
 {
+    assert(kernel);
+    assert(result);
     (void) kernel; // Unused
+
     std::unique_lock lock(m_mutex);
 
     *m_epsilon += *result->deltaEpsilon;

--- a/src/bayeswbase.cpp
+++ b/src/bayeswbase.cpp
@@ -601,9 +601,9 @@ void BayesWBase::sampleTheta(int fix_i){
 }
 
 // Function for sampling marker effect (beta_i)
-void BayesWBase::processColumn(Kernel *kernel)
+void BayesWBase::processColumn(const KernelPtr &kernel)
 {
-    auto * gaussKernel = dynamic_cast<BayesWKernel*>(kernel);
+    auto * gaussKernel = dynamic_cast<BayesWKernel*>(kernel.get());
     assert(gaussKernel);
 
     const double beta_old = m_beta(gaussKernel->marker->i);
@@ -829,9 +829,9 @@ int BayesWBase::runGibbs(AnalysisGraph* analysis)
     return 0;
 }
 
-std::unique_ptr<AsyncResult> BayesWBase::processColumnAsync(Kernel *kernel)
+std::unique_ptr<AsyncResult> BayesWBase::processColumnAsync(const KernelPtr &kernel)
 {
-    auto * gaussKernel = dynamic_cast<BayesWKernel*>(kernel);
+    auto * gaussKernel = dynamic_cast<BayesWKernel*>(kernel.get());
     assert(gaussKernel);
 
     // Local copies required to sample beta

--- a/src/bayeswbase.cpp
+++ b/src/bayeswbase.cpp
@@ -951,7 +951,7 @@ std::unique_ptr<AsyncResult> BayesWBase::processColumnAsync(const KernelPtr &ker
 }
 
 void BayesWBase::updateGlobal(const KernelPtr& kernel,
-                              const std::shared_ptr<const AsyncResult>& result)
+                              const ConstAsyncResultPtr& result)
 {
     assert(kernel);
     assert(result);

--- a/src/bayeswbase.cpp
+++ b/src/bayeswbase.cpp
@@ -950,7 +950,7 @@ std::unique_ptr<AsyncResult> BayesWBase::processColumnAsync(Kernel *kernel)
     return result;
 }
 
-void BayesWBase::updateGlobal(const std::shared_ptr<Kernel>& kernel,
+void BayesWBase::updateGlobal(const KernelPtr& kernel,
                               const std::shared_ptr<const AsyncResult>& result)
 {
     assert(kernel);

--- a/src/bayeswbase.h
+++ b/src/bayeswbase.h
@@ -79,7 +79,7 @@ public:
     void processColumn(const KernelPtr &kernel) override;
     std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) override;
 
-    void updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateGlobal(const KernelPtr& kernel, const ConstAsyncResultPtr &result) override;
 
 protected:
 	void init(unsigned int markerCount, unsigned int individualCount, unsigned int fixedCount);

--- a/src/bayeswbase.h
+++ b/src/bayeswbase.h
@@ -77,8 +77,9 @@ public:
     int runGibbs(AnalysisGraph* analysis) override; // where we run Gibbs sampling over the parametrised model
 
     void processColumn(const KernelPtr &kernel) override;
-    std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) override;
 
+    std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) override;
+    void doThreadSafeUpdates(const ConstAsyncResultPtr& result) override;
     void updateGlobal(const KernelPtr& kernel, const ConstAsyncResultPtr &result) override;
 
 protected:

--- a/src/bayeswbase.h
+++ b/src/bayeswbase.h
@@ -76,8 +76,8 @@ public:
 
     int runGibbs(AnalysisGraph* analysis) override; // where we run Gibbs sampling over the parametrised model
 
-    void processColumn(Kernel *kernel) override;
-    std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) override;
+    void processColumn(const KernelPtr &kernel) override;
+    std::unique_ptr<AsyncResult> processColumnAsync(const KernelPtr &kernel) override;
 
     void updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result) override;
 

--- a/src/bayeswbase.h
+++ b/src/bayeswbase.h
@@ -80,7 +80,7 @@ public:
     void processColumn(Kernel *kernel) override;
     std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) override;
 
-    void updateGlobal(Kernel *kernel, const double beta_old, const double m_beta, const VectorXd &deltaEps) override;
+    void updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult> &result) override;
 
 protected:
 	void init(unsigned int markerCount, unsigned int individualCount, unsigned int fixedCount);

--- a/src/bayeswbase.h
+++ b/src/bayeswbase.h
@@ -67,9 +67,9 @@ protected:
     double m_mu = 0;
     double m_sigma_b = 0;
 
-    mutable std::shared_mutex m_mutex;
-    mutable std::mutex m_rngMutex;
+    std::vector<double> m_randomNumbers;
 
+    mutable std::shared_mutex m_mutex;
 
 public:
     BayesWBase(const Data *data, const Options *opt, const long m_memPageSize);
@@ -89,6 +89,8 @@ protected:
 	void sampleAlpha();
 
     double gauss_hermite_adaptive_integral(int k, double sigma, string n, const BayesWKernel *kernel);
+
+    virtual void prepareForAnalysis();
 
     virtual int estimateBeta (const BayesWKernel *kernel, const std::shared_ptr<VectorXd> &epsilon, double *xinit, int ninit, double *xl, double *xr, const beta_params params,
                           double *convex, int npoint, int dometrop, double *xprev, double *xsamp,

--- a/src/bayeswbase.h
+++ b/src/bayeswbase.h
@@ -80,7 +80,7 @@ public:
     void processColumn(Kernel *kernel) override;
     std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) override;
 
-    void updateGlobal(Kernel *kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateGlobal(const std::shared_ptr<Kernel> &kernel, const std::shared_ptr<const AsyncResult> &result) override;
 
 protected:
 	void init(unsigned int markerCount, unsigned int individualCount, unsigned int fixedCount);

--- a/src/bayeswbase.h
+++ b/src/bayeswbase.h
@@ -16,7 +16,6 @@
 #include <shared_mutex>
 
 struct BayesWKernel;
-struct Kernel;
 
 struct beta_params {
     double alpha = 0;
@@ -80,7 +79,7 @@ public:
     void processColumn(Kernel *kernel) override;
     std::unique_ptr<AsyncResult> processColumnAsync(Kernel *kernel) override;
 
-    void updateGlobal(const std::shared_ptr<Kernel> &kernel, const std::shared_ptr<const AsyncResult> &result) override;
+    void updateGlobal(const KernelPtr& kernel, const std::shared_ptr<const AsyncResult> &result) override;
 
 protected:
 	void init(unsigned int markerCount, unsigned int individualCount, unsigned int fixedCount);

--- a/src/common.h
+++ b/src/common.h
@@ -37,6 +37,9 @@ struct Marker;
 using MarkerPtr = std::shared_ptr<Marker>;
 using ConstMarkerPtr = std::shared_ptr<const Marker>;
 
+struct Kernel;
+using KernelPtr = std::shared_ptr<Kernel>;
+
 class MarkerBuilder;
 MarkerBuilder* builderForType(const PreprocessDataType type);
 

--- a/src/common.h
+++ b/src/common.h
@@ -40,6 +40,9 @@ using ConstMarkerPtr = std::shared_ptr<const Marker>;
 struct Kernel;
 using KernelPtr = std::shared_ptr<Kernel>;
 
+struct AsyncResult;
+using ConstAsyncResultPtr = std::shared_ptr<const AsyncResult>;
+
 class MarkerBuilder;
 MarkerBuilder* builderForType(const PreprocessDataType type);
 

--- a/src/limitsequencegraph.cpp
+++ b/src/limitsequencegraph.cpp
@@ -45,7 +45,7 @@ LimitSequenceGraph::LimitSequenceGraph(size_t maxParallel)
 
     auto g = [this] (Message msg) -> continue_msg {
         // Delegate the processing of this column to the algorithm class
-        m_analysis->processColumn(msg.kernel.get());
+        m_analysis->processColumn(msg.kernel);
 
         // Signal for next decompression task to continue
         return continue_msg();

--- a/src/limitsequencegraph.hpp
+++ b/src/limitsequencegraph.hpp
@@ -2,6 +2,7 @@
 #define LIMITSEQUENCEGRAPH_H
 
 #include "analysisgraph.hpp"
+#include "common.h"
 
 #include "tbb/flow_graph.h"
 #include <functional>
@@ -9,7 +10,6 @@
 
 using namespace tbb::flow;
 
-struct Kernel;
 
 class LimitSequenceGraph : public AnalysisGraph
 {
@@ -29,7 +29,7 @@ private:
         unsigned int id = 0;
         unsigned int snp = 0;
         unsigned int numInds = 0;
-        std::shared_ptr<Kernel> kernel = nullptr;
+        KernelPtr kernel = nullptr;
     };
 
     std::unique_ptr<graph> m_graph;

--- a/src/parallelgraph.cpp
+++ b/src/parallelgraph.cpp
@@ -84,10 +84,7 @@ ParallelGraph::ParallelGraph(size_t maxDecompressionTokens, size_t maxAnalysisTo
         auto &decompressionTuple = std::get<1>(input);
         auto &msg = std::get<1>(decompressionTuple);
 
-        m_analysis->updateGlobal(msg.kernel.get(),
-                              msg.result->betaOld,
-                              msg.result->beta,
-                              *msg.result->deltaEpsilon);
+        m_analysis->updateGlobal(msg.kernel.get(), msg.result);
 
         std::get<0>(outputPorts).try_put(std::get<0>(decompressionTuple));
         std::get<1>(outputPorts).try_put(std::get<0>(input));

--- a/src/parallelgraph.cpp
+++ b/src/parallelgraph.cpp
@@ -84,7 +84,7 @@ ParallelGraph::ParallelGraph(size_t maxDecompressionTokens, size_t maxAnalysisTo
         auto &decompressionTuple = std::get<1>(input);
         auto &msg = std::get<1>(decompressionTuple);
 
-        m_analysis->updateGlobal(msg.kernel.get(), msg.result);
+        m_analysis->updateGlobal(msg.kernel, msg.result);
 
         std::get<0>(outputPorts).try_put(std::get<0>(decompressionTuple));
         std::get<1>(outputPorts).try_put(std::get<0>(input));

--- a/src/parallelgraph.cpp
+++ b/src/parallelgraph.cpp
@@ -52,7 +52,7 @@ ParallelGraph::ParallelGraph(size_t maxDecompressionTokens, size_t maxAnalysisTo
     // Sampling of the column to the async algorithm class
     auto g = [this] (AnalysisTuple tuple) -> AnalysisTuple {
         auto &msg = std::get<1>(std::get<1>(tuple));
-        msg.result = m_analysis->processColumnAsync(msg.kernel.get());
+        msg.result = m_analysis->processColumnAsync(msg.kernel);
         return tuple;
     };
 

--- a/src/parallelgraph.h
+++ b/src/parallelgraph.h
@@ -76,6 +76,9 @@ private:
     using analysis_node = function_node<AnalysisTuple, AnalysisTuple>;
     std::unique_ptr<analysis_node> m_analysisNode;
 
+    using thread_safe_update_node = function_node<AnalysisTuple, AnalysisTuple, lightweight>;
+    std::unique_ptr<thread_safe_update_node> m_threadSafeUpdateNode;
+
     using decision_node = multifunction_node<AnalysisTuple, tbb::flow::tuple<DecompressionToken, AnalysisToken, AnalysisTuple>>;
     std::unique_ptr<decision_node> m_decisionNode;
 

--- a/src/parallelgraph.h
+++ b/src/parallelgraph.h
@@ -53,7 +53,7 @@ private:
         unsigned int snp = 0;
         unsigned int numInds = 0;
         KernelPtr kernel = nullptr;
-        std::shared_ptr<const AsyncResult> result = nullptr;
+        ConstAsyncResultPtr result = nullptr;
     };
 
     using DecompressionTuple = tbb::flow::tuple<DecompressionToken, Message>;

--- a/src/parallelgraph.h
+++ b/src/parallelgraph.h
@@ -2,6 +2,7 @@
 #define DENSEPARALLELGRAPH_H
 
 #include "analysisgraph.hpp"
+#include "common.h"
 
 #include "tbb/flow_graph.h"
 #include <functional>
@@ -10,7 +11,6 @@
 
 class BayesRBase;
 
-struct Kernel;
 struct AsyncResult;
 
 using DecompressionToken = size_t;
@@ -52,7 +52,7 @@ private:
         unsigned int id = 0;
         unsigned int snp = 0;
         unsigned int numInds = 0;
-        std::shared_ptr<Kernel> kernel = nullptr;
+        KernelPtr kernel = nullptr;
         std::shared_ptr<const AsyncResult> result = nullptr;
     };
 

--- a/src/sequential.cpp
+++ b/src/sequential.cpp
@@ -21,7 +21,7 @@ void Sequential::exec(Analysis *analysis,
     }
 
     std::for_each(markerIndices.cbegin(), markerIndices.cend(), [&analysis](unsigned int i) {
-        auto kernel = analysis->kernelForMarker(markerCache()->marker(i));
-        analysis->processColumn(kernel.get());
+        KernelPtr kernel = analysis->kernelForMarker(markerCache()->marker(i));
+        analysis->processColumn(kernel);
     });
 }


### PR DESCRIPTION
This pull request fixes:
- a potential data race when updating `m_epsilon` in the Analysis::updateGlobal functions. Previously it was thought that this function would not be called whilst Analysis::processColumnAsync was called. This was true for a single thread, but not for multi-threaded runs;
- lock contention of the random number generator mutex. Now all random numbers for a run of the flow graph are generated before it is executed;
- reduced lock contention for the remaining mutex by adding a `thread_safe_update_node` to ParallelGraph. `m_v` is now updated in it's own light weight, serial node.