### PR TITLE
Update data.cpp

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -487,7 +487,7 @@ void Data::preprocessCSVFile(const string&csvFile,const string &preprocessedCSVF
       while (std::getline(lineStream, cell, ','))
 	{
 	  if (!cell.empty())
-	    snpData[++cols]=std::stod(cell);
+	    snpData[cols++]=std::stod(cell);
 	  else
 	    throw("Error, there are missing values in the file");
 	}
@@ -561,7 +561,7 @@ void Data::readCSVPhenFile( const string &csvFile)
    while (std::getline(lineStream, cell, ',') && cols<numInds)
    {
        if (!cell.empty())
-           y[++cols]= std::stof(cell);
+           y[cols++]= std::stof(cell);
        else
            throw("Error, there are missing values in the file");
 


### PR DESCRIPTION
Using valgrind, we tracked down the source of an error where data was attempting to be stored in a slot beyond the end of the allocated vectors.

In data.cpp, 'cols' is initiated to start at zero,

```
  uint cols = 0;
```

but

```
y[++cols]= std::stof(cell);
```
put the first entry, when cols=0, into y[1] instead of into y[0].

So here we correct the code to use postfix incrementing instead of prefix incrementing, like this.

```
y[cols++]= std::stof(cell);
```

In this case, when entering this with cols=0, the first entry would be stored in y[0] before cols is incremented to 1.

Similarly, we changed another line to do this:

```
snpData[cols++]=std::stod(cell);
```